### PR TITLE
✨  Add job queue with scheduling and notifications

### DIFF
--- a/ObjectCaptureReconstruction.xcodeproj/project.pbxproj
+++ b/ObjectCaptureReconstruction.xcodeproj/project.pbxproj
@@ -7,18 +7,22 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		26B095472C091BC80097324A /* TopBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B095462C091BC80097324A /* TopBarView.swift */; };
-		26B095492C091BEA0097324A /* BottomBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B095482C091BEA0097324A /* BottomBarView.swift */; };
 		26B0954B2C091C770097324A /* ThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B0954A2C091C770097324A /* ThumbnailView.swift */; };
 		F974D11A2BE0484500EFACBA /* ObjectCaptureReconstructionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D1192BE0484500EFACBA /* ObjectCaptureReconstructionApp.swift */; };
 		F974D11C2BE0484500EFACBA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D11B2BE0484500EFACBA /* ContentView.swift */; };
 		F974D11E2BE0484700EFACBA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F974D11D2BE0484700EFACBA /* Assets.xcassets */; };
 		F974D56A2BE1BCB600EFACBA /* AppDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D5692BE1BCB600EFACBA /* AppDataModel.swift */; };
-		F974D56C2BE1CF0600EFACBA /* ProcessingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D56B2BE1CF0600EFACBA /* ProcessingView.swift */; };
-		F99368C32BE3118600DAA789 /* ModelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99368C22BE3118600DAA789 /* ModelView.swift */; };
 		F9D806832BFE6EA1005A4B94 /* ImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D806822BFE6EA1005A4B94 /* ImageHelper.swift */; };
-		F9F1BEDC2C6433340066F3D3 /* ReprocessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F1BEDB2C6433340066F3D3 /* ReprocessView.swift */; };
-		F9F1BEDD2C6433340066F3D3 /* ReconstructionProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F1BEDA2C6433340066F3D3 /* ReconstructionProgressView.swift */; };
+		4A09793D6E37710A3E5C6A9E /* CodableSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */; };
+		4FEA8298C11A586715309B27 /* ReconstructionJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */; };
+		5BB43283ED23CAD514525CCE /* ScheduleConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */; };
+		0DA909603009039BB1FEB542 /* JobDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */; };
+		4A45C797C462E066F321F944 /* JobScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5722048B055E10C8C4635BA /* JobScheduler.swift */; };
+		8EDA871038ABBECE6E11AF17 /* JobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4F782DCEACB71739E8182 /* JobStore.swift */; };
+		05E9773251F45705785EB1EC /* QueueDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */; };
+		665189C5915C218406A40D61 /* JobRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE344691F76FD3CE82E7FCF /* JobRowView.swift */; };
+		DC9509AE8DE723BBD01EC86D /* JobSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */; };
+		5B7275D8B81A2AA37B5D76A1 /* ScheduleSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +42,16 @@
 		F9D806822BFE6EA1005A4B94 /* ImageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHelper.swift; sourceTree = "<group>"; };
 		F9F1BEDA2C6433340066F3D3 /* ReconstructionProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconstructionProgressView.swift; sourceTree = "<group>"; };
 		F9F1BEDB2C6433340066F3D3 /* ReprocessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReprocessView.swift; sourceTree = "<group>"; };
+		5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableSessionConfiguration.swift; sourceTree = "<group>"; };
+		AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconstructionJob.swift; sourceTree = "<group>"; };
+		958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleConfig.swift; sourceTree = "<group>"; };
+		E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDraft.swift; sourceTree = "<group>"; };
+		A5722048B055E10C8C4635BA /* JobScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobScheduler.swift; sourceTree = "<group>"; };
+		B0C4F782DCEACB71739E8182 /* JobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobStore.swift; sourceTree = "<group>"; };
+		B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueDashboardView.swift; sourceTree = "<group>"; };
+		BCE344691F76FD3CE82E7FCF /* JobRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobRowView.swift; sourceTree = "<group>"; };
+		33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobSetupView.swift; sourceTree = "<group>"; };
+		37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -133,6 +147,10 @@
 				26B0954A2C091C770097324A /* ThumbnailView.swift */,
 				26B095232C091B810097324A /* Processing */,
 				26B095212C091B740097324A /* Settings */,
+				AAC7DC5DCD23638D271D3093 /* Models */,
+				992CB303C65294FA4C0E9608 /* Scheduler */,
+				195BAF6352F89DD77AFC2745 /* Store */,
+				E195DA07BD54DDE970F27E56 /* Queue */,
 				F974D11D2BE0484700EFACBA /* Assets.xcassets */,
 			);
 			path = ObjectCaptureReconstruction;
@@ -145,6 +163,44 @@
 			);
 			name = LICENSE;
 			path = .;
+			sourceTree = "<group>";
+		};
+		AAC7DC5DCD23638D271D3093 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5A00FFF0EB8B4E921061918F /* */,
+				AFC5AB62125CB98EAA9DF3F6 /* */,
+				958B6CDE5F744C8A9E27719D /* */,
+				E3A4F851B39B9C4EA08E7C13 /* */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		992CB303C65294FA4C0E9608 /* Scheduler */ = {
+			isa = PBXGroup;
+			children = (
+				A5722048B055E10C8C4635BA /* */,
+			);
+			path = Scheduler;
+			sourceTree = "<group>";
+		};
+		195BAF6352F89DD77AFC2745 /* Store */ = {
+			isa = PBXGroup;
+			children = (
+				B0C4F782DCEACB71739E8182 /* */,
+			);
+			path = Store;
+			sourceTree = "<group>";
+		};
+		E195DA07BD54DDE970F27E56 /* Queue */ = {
+			isa = PBXGroup;
+			children = (
+				B18D78DD28112179ED6A17EA /* */,
+				BCE344691F76FD3CE82E7FCF /* */,
+				33550E6E2F6D8F14E9A9C282 /* */,
+				37404910B7FC7310289216C7 /* */,
+			);
+			path = Queue;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -217,17 +273,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F99368C32BE3118600DAA789 /* ModelView.swift in Sources */,
-				F9F1BEDC2C6433340066F3D3 /* ReprocessView.swift in Sources */,
-				F9F1BEDD2C6433340066F3D3 /* ReconstructionProgressView.swift in Sources */,
-				26B095492C091BEA0097324A /* BottomBarView.swift in Sources */,
 				F9D806832BFE6EA1005A4B94 /* ImageHelper.swift in Sources */,
-				26B095472C091BC80097324A /* TopBarView.swift in Sources */,
-				F974D56C2BE1CF0600EFACBA /* ProcessingView.swift in Sources */,
 				F974D11C2BE0484500EFACBA /* ContentView.swift in Sources */,
 				F974D56A2BE1BCB600EFACBA /* AppDataModel.swift in Sources */,
 				26B0954B2C091C770097324A /* ThumbnailView.swift in Sources */,
 				F974D11A2BE0484500EFACBA /* ObjectCaptureReconstructionApp.swift in Sources */,
+				4A09793D6E37710A3E5C6A9E /* CodableSessionConfiguration.swift in Sources */,
+				4FEA8298C11A586715309B27 /* ReconstructionJob.swift in Sources */,
+				5BB43283ED23CAD514525CCE /* ScheduleConfig.swift in Sources */,
+				0DA909603009039BB1FEB542 /* JobDraft.swift in Sources */,
+				4A45C797C462E066F321F944 /* JobScheduler.swift in Sources */,
+				8EDA871038ABBECE6E11AF17 /* JobStore.swift in Sources */,
+				05E9773251F45705785EB1EC /* QueueDashboardView.swift in Sources */,
+				665189C5915C218406A40D61 /* JobRowView.swift in Sources */,
+				DC9509AE8DE723BBD01EC86D /* JobSetupView.swift in Sources */,
+				5B7275D8B81A2AA37B5D76A1 /* ScheduleSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ObjectCaptureReconstruction/AppDataModel.swift
+++ b/ObjectCaptureReconstruction/AppDataModel.swift
@@ -1,8 +1,8 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
-Data model for maintaining the app state.
+Data model for maintaining the app state and the job queue.
 */
 
 import Foundation
@@ -14,134 +14,32 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
 
 @MainActor @Observable class AppDataModel {
     enum State: Equatable {
-        case ready
-        case reconstructing
-        case viewing
+        case idle
+        case scheduling
         case error
     }
 
-    // The session to manage the creation of 3D models.
-    private(set) var session: PhotogrammetrySession?
-
-    // App's current state.
-    var state: State = .ready {
+    var state: State = .idle {
         didSet {
             logger.log("State switched to \(String(describing: self.state))")
-            if state == .ready { session = nil }
         }
     }
 
-    // The folder where the images are stored.
-    var imageFolder: URL?
+    let scheduler = JobScheduler()
 
-    // The folder where the models are stored.
-    var modelFolder: URL?
-
-    // The model name selected by the person.
-    var modelName: String?
-
-    // The first generated model file to display through ModelView.
-    var modelFileURLToDisplay: URL?
-
-    // The session configuration set by the person in SettingsView.
-    var sessionConfiguration: PhotogrammetrySession.Configuration = PhotogrammetrySession.Configuration()
-
-    // The detail levels that show up under the Quality menu in SettingsView.
-    var detailLevelOptionUnderQualityMenu = PhotogrammetrySession.Request.Detail.medium
-
-    struct DetailLevelOptionsUnderAdvancedMenu {
-        var isSelected = false
-        var preview = false
-        var reduced = false
-        var medium = false
-        var full = false
-        var raw = false
-    }
-
-    // The detail levels that show up under the Advanced Reconstruction Options in SettingsView.
-    var detailLevelOptionsUnderAdvancedMenu = DetailLevelOptionsUnderAdvancedMenu()
-
-    // The alert message shown in the pop up when the app goes into the error state.
     var alertMessage: String = ""
 
-    // This is the number of models that the person has requested.
-    var numRequestedModels = 0
-    
-    // Used to enable or disable the crop menu option.
-    var boundingBoxAvailable = false
+    /// Whether the job-setup sheet is presented.
+    var showingJobSetup = false
 
-    // Creates a PhotogrammetrySession to generate 3D models for all detail levels requested by the person for the images in the imageFolder.
-    // The models are saved in the modelFolder. The model name consists of the modelName and its detail level.
-    func startReconstruction() async {
-        logger.log("Starting the reconstruction...")
-        // Go to the error state if the required fields aren't filled.
-        guard let imageFolder = imageFolder else {
-            alertMessage = "Image folder is not selected"
-            state = .error
-            logger.info("\(self.alertMessage)")
-            return
-        }
-        guard modelName != nil else {
-            alertMessage = "Model name is not selected"
-            state = .error
-            logger.info("\(self.alertMessage)")
-            return
-        }
-        guard modelFolder != nil else {
-            alertMessage = "Model folder is not selected"
-            state = .error
-            logger.info("\(self.alertMessage)")
-            return
-        }
+    /// Whether the schedule-settings sheet is presented.
+    var showingScheduleSettings = false
 
-        let requests = createReconstructionRequests()
-        guard !requests.isEmpty else { return }
-        numRequestedModels = requests.count
+    /// Draft job being edited in the setup sheet (`nil` when adding a new job).
+    var editingJob: ReconstructionJob?
 
-        // Update the app's state so that ProcessingView is visible.
-        state = .reconstructing
-
-        do {
-            // Create the session.
-            logger.log("Creating the session...")
-            session = try await createSession(imageFolder: imageFolder, configuration: sessionConfiguration)
-
-            // Start processing the requests.
-            logger.log("Processing requests...")
-            try session?.process(requests: requests)
-            logger.log("Processing requests started...")
-        } catch {
-            logger.warning("Creating the session or processing the session failed!")
-            alertMessage = "\(error)"
-            state = .error
-        }
-    }
-
-    // Create a PhotogrammetrySession asynchronously.
-    private nonisolated func createSession(imageFolder: URL,
-                                           configuration: PhotogrammetrySession.Configuration) async throws -> PhotogrammetrySession {
-        logger.log("Creating PhotogrammetrySession with \(String(describing: configuration))")
-        return try PhotogrammetrySession(input: imageFolder, configuration: configuration)
-    }
-
-    private func createReconstructionRequests() -> [PhotogrammetrySession.Request] {
-        // Get a list of all detail levels selected by the person through both the Quality menu and under the Advanced Reconstruction options.
-        var detailLevelList: Set<PhotogrammetrySession.Request.Detail> = [detailLevelOptionUnderQualityMenu]
-        if detailLevelOptionsUnderAdvancedMenu.isSelected {
-            if detailLevelOptionsUnderAdvancedMenu.preview { detailLevelList.insert(.preview) }
-            if detailLevelOptionsUnderAdvancedMenu.reduced { detailLevelList.insert(.reduced) }
-            if detailLevelOptionsUnderAdvancedMenu.medium { detailLevelList.insert(.medium) }
-            if detailLevelOptionsUnderAdvancedMenu.full { detailLevelList.insert(.full) }
-            if detailLevelOptionsUnderAdvancedMenu.raw { detailLevelList.insert(.raw) }
-        }
-
-        // Create a request for each detail level.
-        var requests: [PhotogrammetrySession.Request] = []
-        for detailLevel in detailLevelList {
-            let modelFileURL = modelFolder!.appending(path: (modelName!) + "-\(detailLevel)" + ".usdz")
-            requests.append(PhotogrammetrySession.Request.modelFile(url: modelFileURL, detail: detailLevel))
-        }
-        return requests
+    init() {
+        scheduler.loadFromDisk()
     }
 }
 

--- a/ObjectCaptureReconstruction/ContentView.swift
+++ b/ObjectCaptureReconstruction/ContentView.swift
@@ -1,8 +1,8 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
-The top-level view.
+The top-level view routing between the queue dashboard and job setup.
 */
 
 import SwiftUI
@@ -12,33 +12,26 @@ struct ContentView: View {
     @State private var showErrorAlert = false
 
     var body: some View {
-        VStack {
-            switch appDataModel.state {
-            case .ready:
-                SettingsView()
-                    .padding()
-
-                Spacer()
-
-            case .reconstructing, .viewing:
-                ProcessingView()
- 
-            case .error:
-                // In the error state, an alert gets displayed through the alert modifier on this view.
-                EmptyView()
+        QueueDashboardView()
+            .environment(appDataModel)
+            .navigationTitle("Reality Pulse")
+            .sheet(isPresented: $appDataModel.showingJobSetup) {
+                JobSetupView(existingJob: appDataModel.editingJob)
+                    .environment(appDataModel)
             }
-        }
-        .environment(appDataModel)
-        .navigationTitle("Create 3D Model")
-        .onChange(of: appDataModel.state) {
-            if appDataModel.state == .error {
-                showErrorAlert = true
+            .sheet(isPresented: $appDataModel.showingScheduleSettings) {
+                ScheduleSettingsView()
+                    .environment(appDataModel)
             }
-        }
-        .alert(appDataModel.alertMessage, isPresented: $showErrorAlert) {
-            Button("OK") {
-                appDataModel.state = .ready
+            .onChange(of: appDataModel.state) {
+                if appDataModel.state == .error {
+                    showErrorAlert = true
+                }
             }
-        }
+            .alert(appDataModel.alertMessage, isPresented: $showErrorAlert) {
+                Button("OK") {
+                    appDataModel.state = .idle
+                }
+            }
     }
 }

--- a/ObjectCaptureReconstruction/Models/CodableSessionConfiguration.swift
+++ b/ObjectCaptureReconstruction/Models/CodableSessionConfiguration.swift
@@ -1,0 +1,141 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Codable mirror of PhotogrammetrySession.Configuration for JSON persistence.
+*/
+
+import Foundation
+import RealityKit
+
+/// A fully `Codable` representation of `PhotogrammetrySession.Configuration`
+/// and its nested types. Convert to/from the real framework type with
+/// `toSessionConfiguration()` and `init(from:)`.
+struct CodableSessionConfiguration: Codable, Equatable {
+
+    // MARK: - Top-level fields
+
+    var meshPrimitive: CodableMeshPrimitive = .triangle
+    var isObjectMaskingEnabled: Bool = true
+    var ignoreBoundingBox: Bool = false
+    var customDetailSpecification: CodableCustomDetailSpecification = CodableCustomDetailSpecification()
+
+    // MARK: - Nested Codable types
+
+    enum CodableMeshPrimitive: String, Codable, CaseIterable {
+        case triangle
+        case quad
+
+        init(from primitive: PhotogrammetrySession.Configuration.MeshPrimitive) {
+            switch primitive {
+            case .triangle: self = .triangle
+            case .quad: self = .quad
+            @unknown default: self = .triangle
+            }
+        }
+
+        var toFrameworkType: PhotogrammetrySession.Configuration.MeshPrimitive {
+            switch self {
+            case .triangle: return .triangle
+            case .quad: return .quad
+            }
+        }
+    }
+
+    struct CodableCustomDetailSpecification: Codable, Equatable {
+        var maximumPolygonCount: UInt = 0
+        var outputTextureMapsRawValue: UInt = 1 // diffuseColor by default
+        var textureFormat: CodableTextureFormat = .png
+        var maximumTextureDimension: CodableTextureDimension = .fourK
+
+        init() {
+            let defaults = PhotogrammetrySession.Configuration.CustomDetailSpecification()
+            outputTextureMapsRawValue = defaults.outputTextureMaps.rawValue
+            maximumPolygonCount = defaults.maximumPolygonCount
+        }
+
+        init(from spec: PhotogrammetrySession.Configuration.CustomDetailSpecification) {
+            maximumPolygonCount = spec.maximumPolygonCount
+            outputTextureMapsRawValue = spec.outputTextureMaps.rawValue
+            textureFormat = CodableTextureFormat(from: spec.textureFormat)
+            maximumTextureDimension = CodableTextureDimension(from: spec.maximumTextureDimension)
+        }
+
+        func toFrameworkType() -> PhotogrammetrySession.Configuration.CustomDetailSpecification {
+            var spec = PhotogrammetrySession.Configuration.CustomDetailSpecification()
+            spec.maximumPolygonCount = maximumPolygonCount
+            spec.outputTextureMaps = .init(rawValue: outputTextureMapsRawValue)
+            spec.textureFormat = textureFormat.toFrameworkType
+            spec.maximumTextureDimension = maximumTextureDimension.toFrameworkType
+            return spec
+        }
+    }
+
+    enum CodableTextureFormat: Codable, Equatable {
+        case png
+        case jpeg(compressionQuality: Float)
+
+        init(from format: PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureFormat) {
+            switch format {
+            case .png:
+                self = .png
+            case .jpeg(let quality):
+                self = .jpeg(compressionQuality: quality)
+            @unknown default:
+                self = .png
+            }
+        }
+
+        var toFrameworkType: PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureFormat {
+            switch self {
+            case .png: return .png
+            case .jpeg(let quality): return .jpeg(compressionQuality: quality)
+            }
+        }
+    }
+
+    enum CodableTextureDimension: String, Codable, CaseIterable {
+        case oneK, twoK, fourK, eightK, sixteenK
+
+        init(from dimension: PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureDimension) {
+            switch dimension {
+            case .oneK: self = .oneK
+            case .twoK: self = .twoK
+            case .fourK: self = .fourK
+            case .eightK: self = .eightK
+            case .sixteenK: self = .sixteenK
+            @unknown default: self = .fourK
+            }
+        }
+
+        var toFrameworkType: PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureDimension {
+            switch self {
+            case .oneK: return .oneK
+            case .twoK: return .twoK
+            case .fourK: return .fourK
+            case .eightK: return .eightK
+            case .sixteenK: return .sixteenK
+            }
+        }
+    }
+
+    // MARK: - Conversion
+
+    init() {}
+
+    init(from config: PhotogrammetrySession.Configuration) {
+        meshPrimitive = CodableMeshPrimitive(from: config.meshPrimitive)
+        isObjectMaskingEnabled = config.isObjectMaskingEnabled
+        ignoreBoundingBox = config.ignoreBoundingBox
+        customDetailSpecification = CodableCustomDetailSpecification(from: config.customDetailSpecification)
+    }
+
+    func toSessionConfiguration() -> PhotogrammetrySession.Configuration {
+        var config = PhotogrammetrySession.Configuration()
+        config.meshPrimitive = meshPrimitive.toFrameworkType
+        config.isObjectMaskingEnabled = isObjectMaskingEnabled
+        config.ignoreBoundingBox = ignoreBoundingBox
+        config.customDetailSpecification = customDetailSpecification.toFrameworkType()
+        return config
+    }
+}

--- a/ObjectCaptureReconstruction/Models/JobDraft.swift
+++ b/ObjectCaptureReconstruction/Models/JobDraft.swift
@@ -1,0 +1,94 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Observable draft for editing a reconstruction job in the setup sheet.
+Exposes the same property interface as the old AppDataModel so that
+settings views require only a type-name change in @Environment.
+*/
+
+import Foundation
+import RealityKit
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "JobDraft")
+
+@MainActor @Observable class JobDraft {
+
+    // MARK: - Folder / name (same names as old AppDataModel)
+
+    var imageFolder: URL?
+    var modelFolder: URL?
+    var modelName: String?
+    var boundingBoxAvailable = false
+
+    // MARK: - Session configuration (live framework type for picker bindings)
+
+    var sessionConfiguration: PhotogrammetrySession.Configuration = PhotogrammetrySession.Configuration()
+    var detailLevelOptionUnderQualityMenu: PhotogrammetrySession.Request.Detail = .medium
+    var detailLevelOptionsUnderAdvancedMenu = CodableDetailLevelOptions()
+
+    // MARK: - Error surface (used by ImageFolderView, ModelFolderView, etc.)
+
+    var alertMessage: String = ""
+    var hasError: Bool = false
+
+    // MARK: - Init
+
+    /// Create an empty draft for a new job.
+    init() {}
+
+    /// Create a draft pre-filled from an existing job for editing.
+    init(from job: ReconstructionJob) {
+        imageFolder = job.imageFolder
+        modelFolder = job.modelFolder
+        modelName = job.modelName
+        boundingBoxAvailable = job.boundingBoxAvailable
+
+        sessionConfiguration = job.sessionConfiguration.toSessionConfiguration()
+        detailLevelOptionUnderQualityMenu = job.primaryDetailLevel.toFrameworkType
+        detailLevelOptionsUnderAdvancedMenu = job.additionalDetailLevels
+    }
+
+    // MARK: - Conversion
+
+    /// Build a `ReconstructionJob` from the current draft.
+    /// Returns `nil` if required fields are missing.
+    func toJob(existingId: UUID? = nil) -> ReconstructionJob? {
+        guard let imageFolder, let modelFolder, let modelName, !modelName.isEmpty else {
+            return nil
+        }
+
+        var job = ReconstructionJob(
+            imageFolder: imageFolder,
+            modelFolder: modelFolder,
+            modelName: modelName,
+            sessionConfiguration: CodableSessionConfiguration(from: sessionConfiguration),
+            primaryDetailLevel: CodableDetailLevel(from: detailLevelOptionUnderQualityMenu),
+            additionalDetailLevels: detailLevelOptionsUnderAdvancedMenu
+        )
+        job.boundingBoxAvailable = boundingBoxAvailable
+        return job
+    }
+
+    /// Validate required fields and set the error state if anything is missing.
+    func validate() -> Bool {
+        if imageFolder == nil {
+            alertMessage = "Image folder is not selected"
+            hasError = true
+            return false
+        }
+        if modelName == nil || modelName!.isEmpty {
+            alertMessage = "Model name is not entered"
+            hasError = true
+            return false
+        }
+        if modelFolder == nil {
+            alertMessage = "Output folder is not selected"
+            hasError = true
+            return false
+        }
+        return true
+    }
+}

--- a/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
+++ b/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
@@ -1,0 +1,159 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Data model for a single reconstruction job in the batch queue.
+*/
+
+import Foundation
+import RealityKit
+
+/// Represents a single reconstruction job: one image folder producing one or
+/// more 3D models at the selected detail levels.
+struct ReconstructionJob: Identifiable, Codable {
+    let id: UUID
+    var imageFolder: URL
+    var modelFolder: URL
+    var modelName: String
+
+    var sessionConfiguration: CodableSessionConfiguration
+    var primaryDetailLevel: CodableDetailLevel
+    var additionalDetailLevels: CodableDetailLevelOptions
+
+    var status: JobStatus = .pending
+    var progress: Double = 0
+    var errorMessage: String?
+    var boundingBoxAvailable: Bool = false
+    var createdAt: Date
+
+    /// Security-scoped bookmark data for persisting sandbox access across launches.
+    var imageFolderBookmark: Data?
+    var modelFolderBookmark: Data?
+
+    init(
+        imageFolder: URL,
+        modelFolder: URL,
+        modelName: String,
+        sessionConfiguration: CodableSessionConfiguration = CodableSessionConfiguration(),
+        primaryDetailLevel: CodableDetailLevel = .medium,
+        additionalDetailLevels: CodableDetailLevelOptions = CodableDetailLevelOptions()
+    ) {
+        self.id = UUID()
+        self.imageFolder = imageFolder
+        self.modelFolder = modelFolder
+        self.modelName = modelName
+        self.sessionConfiguration = sessionConfiguration
+        self.primaryDetailLevel = primaryDetailLevel
+        self.additionalDetailLevels = additionalDetailLevels
+        self.createdAt = Date()
+
+        self.imageFolderBookmark = try? imageFolder.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+        self.modelFolderBookmark = try? modelFolder.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+    }
+
+    // MARK: - Detail level helpers
+
+    /// All detail levels requested for this job (primary + any advanced selections).
+    var allRequestedDetailLevels: Set<CodableDetailLevel> {
+        var levels: Set<CodableDetailLevel> = [primaryDetailLevel]
+        if additionalDetailLevels.isSelected {
+            if additionalDetailLevels.preview { levels.insert(.preview) }
+            if additionalDetailLevels.reduced { levels.insert(.reduced) }
+            if additionalDetailLevels.medium { levels.insert(.medium) }
+            if additionalDetailLevels.full { levels.insert(.full) }
+            if additionalDetailLevels.raw { levels.insert(.raw) }
+        }
+        return levels
+    }
+
+    /// Build `PhotogrammetrySession.Request` entries for all requested detail levels.
+    func createReconstructionRequests() -> [PhotogrammetrySession.Request] {
+        allRequestedDetailLevels.map { level in
+            let url = modelFolder.appending(path: "\(modelName)-\(level.rawValue).usdz")
+            return .modelFile(url: url, detail: level.toFrameworkType)
+        }
+    }
+
+    // MARK: - Bookmark resolution
+
+    /// Resolve security-scoped bookmarks to restore sandbox access after relaunch.
+    /// Returns updated URLs; callers must call `startAccessingSecurityScopedResource`.
+    mutating func resolveBookmarks() -> (image: URL?, model: URL?) {
+        var imageURL: URL?
+        var modelURL: URL?
+
+        if let data = imageFolderBookmark {
+            var stale = false
+            if let url = try? URL(resolvingBookmarkData: data, options: .withSecurityScope, bookmarkDataIsStale: &stale) {
+                imageURL = url
+                imageFolder = url
+                if stale { imageFolderBookmark = try? url.bookmarkData(options: .withSecurityScope) }
+            }
+        }
+
+        if let data = modelFolderBookmark {
+            var stale = false
+            if let url = try? URL(resolvingBookmarkData: data, options: .withSecurityScope, bookmarkDataIsStale: &stale) {
+                modelURL = url
+                modelFolder = url
+                if stale { modelFolderBookmark = try? url.bookmarkData(options: .withSecurityScope) }
+            }
+        }
+
+        return (imageURL, modelURL)
+    }
+}
+
+// MARK: - Supporting types
+
+enum JobStatus: String, Codable, CaseIterable {
+    case pending
+    case running
+    case completed
+    case failed
+    case cancelled
+}
+
+enum CodableDetailLevel: String, Codable, CaseIterable, Hashable {
+    case preview, reduced, medium, full, raw, custom
+
+    init(from detail: PhotogrammetrySession.Request.Detail) {
+        switch detail {
+        case .preview:  self = .preview
+        case .reduced:  self = .reduced
+        case .medium:   self = .medium
+        case .full:     self = .full
+        case .raw:      self = .raw
+        case .custom:   self = .custom
+        @unknown default: self = .medium
+        }
+    }
+
+    var toFrameworkType: PhotogrammetrySession.Request.Detail {
+        switch self {
+        case .preview:  return .preview
+        case .reduced:  return .reduced
+        case .medium:   return .medium
+        case .full:     return .full
+        case .raw:      return .raw
+        case .custom:   return .custom
+        }
+    }
+}
+
+struct CodableDetailLevelOptions: Codable, Equatable {
+    var isSelected: Bool = false
+    var preview: Bool = false
+    var reduced: Bool = false
+    var medium: Bool = false
+    var full: Bool = false
+    var raw: Bool = false
+}

--- a/ObjectCaptureReconstruction/Models/ScheduleConfig.swift
+++ b/ObjectCaptureReconstruction/Models/ScheduleConfig.swift
@@ -1,0 +1,97 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Configuration for delayed-start and allowed-hours scheduling.
+*/
+
+import Foundation
+
+/// Defines when the scheduler is allowed to process jobs.
+struct ScheduleConfig: Codable, Equatable {
+
+    /// Optional one-time delayed start. The scheduler will not begin processing
+    /// until this date has passed.
+    var delayedStart: Date?
+
+    /// Optional recurring allowed-hours window expressed as start/end hours (0-23).
+    /// When set, the scheduler only processes during these hours, pausing outside.
+    /// The window can wrap midnight (e.g., start=22, end=6 means 10 PM to 6 AM).
+    var allowedWindowStart: Int?
+    var allowedWindowEnd: Int?
+
+    var hasAllowedWindow: Bool {
+        allowedWindowStart != nil && allowedWindowEnd != nil
+    }
+
+    // MARK: - Time-window evaluation
+
+    /// Whether the scheduler is allowed to run at the given time.
+    func isWithinAllowedWindow(now: Date = Date()) -> Bool {
+        // If there's a delayed start that hasn't passed, not allowed.
+        if let start = delayedStart, now < start {
+            return false
+        }
+
+        // If no window is configured, always allowed.
+        guard let startHour = allowedWindowStart, let endHour = allowedWindowEnd else {
+            return true
+        }
+
+        let hour = Calendar.current.component(.hour, from: now)
+
+        if startHour <= endHour {
+            // Same-day window (e.g., 9–17)
+            return hour >= startHour && hour < endHour
+        } else {
+            // Wraps midnight (e.g., 22–6)
+            return hour >= startHour || hour < endHour
+        }
+    }
+
+    /// Returns the next `Date` at which the allowed window opens,
+    /// or `nil` if no window is configured.
+    func nextWindowOpen(after date: Date = Date()) -> Date? {
+        // Handle delayed start first.
+        if let start = delayedStart, date < start {
+            // If there's also a window, the actual start is whichever is later.
+            if let windowDate = nextAllowedWindowDate(after: start) {
+                return isWithinHourWindow(at: start) ? start : windowDate
+            }
+            return start
+        }
+
+        return nextAllowedWindowDate(after: date)
+    }
+
+    // MARK: - Private helpers
+
+    private func nextAllowedWindowDate(after date: Date) -> Date? {
+        guard let startHour = allowedWindowStart, allowedWindowEnd != nil else { return nil }
+
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.year, .month, .day], from: date)
+        components.hour = startHour
+        components.minute = 0
+        components.second = 0
+
+        guard var candidate = calendar.date(from: components) else { return nil }
+
+        // If the candidate is in the past or we're already in the window, advance a day.
+        if candidate <= date || isWithinHourWindow(at: date) {
+            candidate = calendar.date(byAdding: .day, value: 1, to: candidate) ?? candidate
+        }
+
+        return candidate
+    }
+
+    private func isWithinHourWindow(at date: Date) -> Bool {
+        guard let startHour = allowedWindowStart, let endHour = allowedWindowEnd else { return true }
+        let hour = Calendar.current.component(.hour, from: date)
+        if startHour <= endHour {
+            return hour >= startHour && hour < endHour
+        } else {
+            return hour >= startHour || hour < endHour
+        }
+    }
+}

--- a/ObjectCaptureReconstruction/ObjectCaptureReconstructionApp.swift
+++ b/ObjectCaptureReconstruction/ObjectCaptureReconstructionApp.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Top-level app structure of the view hierarchy.
@@ -12,10 +12,10 @@ struct ObjectCaptureReconstructionApp: App {
     static let subsystem: String = "com.example.apple-samplecode.ObjectCaptureReconstruction"
 
     var body: some Scene {
-        Window("ObjectCaptureReconstruction", id: "main") {
+        Window("Reality Pulse", id: "main") {
             ContentView()
-                .frame(width: 400, height: 360)
+                .frame(minWidth: 700, minHeight: 500)
         }
-        .windowResizability(.contentSize)
+        .defaultSize(width: 800, height: 600)
     }
 }

--- a/ObjectCaptureReconstruction/Queue/JobRowView.swift
+++ b/ObjectCaptureReconstruction/Queue/JobRowView.swift
@@ -1,0 +1,88 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+A single row in the job queue list showing status, folder, detail levels, and progress.
+*/
+
+import SwiftUI
+
+struct JobRowView: View {
+    let job: ReconstructionJob
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+
+    var body: some View {
+        HStack(spacing: 10) {
+            statusIcon
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(job.modelName)
+                    .fontWeight(.medium)
+
+                HStack(spacing: 4) {
+                    Image(systemName: "folder")
+                        .font(.caption2)
+                    Text(job.imageFolder.lastPathComponent)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Text(detailLevelSummary)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+
+            if job.status == .running {
+                VStack(alignment: .trailing, spacing: 2) {
+                    ProgressView(value: job.progress)
+                        .frame(width: 80)
+
+                    Text("\(Int(job.progress * 100))%")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            } else if job.status == .failed {
+                Text(job.errorMessage ?? "Failed")
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .lineLimit(1)
+                    .frame(maxWidth: 120)
+                    .help(job.errorMessage ?? "Failed")
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch job.status {
+        case .pending:
+            Image(systemName: "clock")
+                .foregroundStyle(.secondary)
+        case .running:
+            ProgressView()
+                .scaleEffect(0.6)
+        case .completed:
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .failed:
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+        case .cancelled:
+            Image(systemName: "xmark.circle")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var detailLevelSummary: String {
+        let levels = job.allRequestedDetailLevels
+            .map { $0.rawValue.capitalized }
+            .sorted()
+            .joined(separator: ", ")
+        return levels.isEmpty ? "No detail levels" : levels
+    }
+}

--- a/ObjectCaptureReconstruction/Queue/JobSetupView.swift
+++ b/ObjectCaptureReconstruction/Queue/JobSetupView.swift
@@ -1,0 +1,54 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Sheet for adding or editing a reconstruction job.
+*/
+
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "JobSetupView")
+
+struct JobSetupView: View {
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @State private var draft: JobDraft
+
+    private let isEditing: Bool
+
+    init(existingJob: ReconstructionJob? = nil) {
+        if let job = existingJob {
+            _draft = State(initialValue: JobDraft(from: job))
+            isEditing = true
+        } else {
+            _draft = State(initialValue: JobDraft())
+            isEditing = false
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(isEditing ? "Edit Job" : "New Job")
+                .font(.headline)
+                .padding(.top)
+
+            Divider()
+                .padding(.top, 8)
+
+            SettingsView()
+                .padding()
+
+            Divider()
+                .padding(.horizontal, -20)
+
+            ProcessButton(isEditing: isEditing)
+                .padding()
+        }
+        .environment(draft)
+        .frame(minWidth: 400, minHeight: 360)
+        .alert(draft.alertMessage, isPresented: $draft.hasError) {
+            Button("OK") {}
+        }
+    }
+}

--- a/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
+++ b/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
@@ -1,0 +1,186 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Main dashboard showing the job queue, scheduler controls, and overall progress.
+*/
+
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "QueueDashboardView")
+
+struct QueueDashboardView: View {
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header with queue controls
+            QueueHeaderView()
+
+            Divider()
+
+            // Job list
+            if appDataModel.scheduler.jobs.isEmpty {
+                emptyState
+            } else {
+                jobList
+            }
+
+            Divider()
+
+            // Footer with add/schedule buttons
+            QueueFooterView()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "cube.transparent")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 60)
+                .foregroundStyle(.tertiary)
+                .fontWeight(.ultraLight)
+
+            Text("No jobs in queue")
+                .foregroundStyle(.secondary)
+
+            Text("Add a job to get started")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var jobList: some View {
+        List {
+            ForEach(appDataModel.scheduler.jobs) { job in
+                JobRowView(job: job)
+                    .contextMenu {
+                        if job.status == .pending {
+                            Button("Edit") {
+                                appDataModel.editingJob = job
+                                appDataModel.showingJobSetup = true
+                            }
+                        }
+
+                        if job.status == .failed {
+                            Button("Retry") {
+                                appDataModel.scheduler.retryJob(job)
+                            }
+                        }
+
+                        if job.status == .pending || job.status == .failed || job.status == .cancelled {
+                            Button("Remove", role: .destructive) {
+                                appDataModel.scheduler.removeJob(job)
+                            }
+                        }
+                    }
+            }
+            .onMove { source, destination in
+                appDataModel.scheduler.moveJob(from: source, to: destination)
+            }
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+}
+
+// MARK: - Header
+
+private struct QueueHeaderView: View {
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Job Queue")
+                    .font(.headline)
+
+                Text(statusSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if appDataModel.scheduler.isRunning {
+                if appDataModel.scheduler.isPaused {
+                    Button("Resume") {
+                        appDataModel.scheduler.resume()
+                    }
+                } else {
+                    Button("Pause") {
+                        appDataModel.scheduler.pause()
+                    }
+                }
+
+                Button("Stop") {
+                    appDataModel.scheduler.cancel()
+                }
+                .foregroundStyle(.red)
+            } else if appDataModel.scheduler.pendingJobCount > 0 {
+                Button("Start") {
+                    appDataModel.scheduler.start()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+    }
+
+    private var statusSummary: String {
+        let scheduler = appDataModel.scheduler
+        let total = scheduler.jobs.count
+        let completed = scheduler.completedJobCount
+        let pending = scheduler.pendingJobCount
+
+        if scheduler.isRunning {
+            if scheduler.isPaused {
+                return "Paused — \(completed)/\(total) complete"
+            }
+            return "Processing — \(completed)/\(total) complete"
+        }
+
+        if total == 0 { return "Empty" }
+        if pending == 0 && completed == total { return "All \(total) jobs complete" }
+        return "\(pending) pending, \(completed) complete"
+    }
+}
+
+// MARK: - Footer
+
+private struct QueueFooterView: View {
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+
+    var body: some View {
+        HStack {
+            Button {
+                appDataModel.showingScheduleSettings = true
+            } label: {
+                Label("Schedule", systemImage: "clock")
+            }
+
+            if appDataModel.scheduler.scheduleConfig.delayedStart != nil ||
+               appDataModel.scheduler.scheduleConfig.hasAllowedWindow {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.caption)
+            }
+
+            Spacer()
+
+            Button {
+                appDataModel.editingJob = nil
+                appDataModel.showingJobSetup = true
+            } label: {
+                Label("Add Job", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}

--- a/ObjectCaptureReconstruction/Queue/ScheduleSettingsView.swift
+++ b/ObjectCaptureReconstruction/Queue/ScheduleSettingsView.swift
@@ -1,0 +1,132 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Configure delayed start and allowed-hours window for the scheduler.
+*/
+
+import SwiftUI
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "ScheduleSettingsView")
+
+struct ScheduleSettingsView: View {
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var useDelayedStart = false
+    @State private var delayedStartDate = Date()
+    @State private var useAllowedWindow = false
+    @State private var windowStartHour = 22
+    @State private var windowEndHour = 6
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("Schedule Settings")
+                .font(.headline)
+                .padding(.top)
+
+            Divider()
+                .padding(.top, 8)
+
+            Form {
+                // Delayed start
+                Section {
+                    Toggle("Delay start until:", isOn: $useDelayedStart)
+
+                    if useDelayedStart {
+                        DatePicker("Start at:", selection: $delayedStartDate, in: Date()...,
+                                   displayedComponents: [.date, .hourAndMinute])
+                    }
+                }
+
+                Divider()
+
+                // Allowed window
+                Section {
+                    Toggle("Only process during allowed hours:", isOn: $useAllowedWindow)
+
+                    if useAllowedWindow {
+                        Picker("From:", selection: $windowStartHour) {
+                            ForEach(0..<24) { hour in
+                                Text(formattedHour(hour)).tag(hour)
+                            }
+                        }
+
+                        Picker("Until:", selection: $windowEndHour) {
+                            ForEach(0..<24) { hour in
+                                Text(formattedHour(hour)).tag(hour)
+                            }
+                        }
+
+                        Text(windowDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding()
+
+            Divider()
+
+            HStack {
+                Button("Clear") {
+                    appDataModel.scheduler.scheduleConfig = ScheduleConfig()
+                    appDataModel.scheduler.persist()
+                    dismiss()
+                }
+
+                Spacer()
+
+                Button("Cancel") {
+                    dismiss()
+                }
+
+                Button("Save") {
+                    var config = ScheduleConfig()
+                    if useDelayedStart {
+                        config.delayedStart = delayedStartDate
+                    }
+                    if useAllowedWindow {
+                        config.allowedWindowStart = windowStartHour
+                        config.allowedWindowEnd = windowEndHour
+                    }
+                    appDataModel.scheduler.scheduleConfig = config
+                    appDataModel.scheduler.persist()
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        }
+        .frame(minWidth: 380, minHeight: 300)
+        .onAppear {
+            let config = appDataModel.scheduler.scheduleConfig
+            useDelayedStart = config.delayedStart != nil
+            delayedStartDate = config.delayedStart ?? Date()
+            useAllowedWindow = config.hasAllowedWindow
+            windowStartHour = config.allowedWindowStart ?? 22
+            windowEndHour = config.allowedWindowEnd ?? 6
+        }
+    }
+
+    private func formattedHour(_ hour: Int) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h a"
+        var components = DateComponents()
+        components.hour = hour
+        if let date = Calendar.current.date(from: components) {
+            return formatter.string(from: date)
+        }
+        return "\(hour):00"
+    }
+
+    private var windowDescription: String {
+        if windowStartHour <= windowEndHour {
+            return "Processing allowed from \(formattedHour(windowStartHour)) to \(formattedHour(windowEndHour))"
+        } else {
+            return "Processing allowed from \(formattedHour(windowStartHour)) overnight to \(formattedHour(windowEndHour))"
+        }
+    }
+}

--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -1,0 +1,330 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Sequential job scheduler that processes reconstruction jobs one at a time,
+respecting optional time-window constraints.
+*/
+
+import Foundation
+import RealityKit
+import UserNotifications
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "JobScheduler")
+
+/// Processes reconstruction jobs sequentially. Before each job, the scheduler
+/// checks the configured time window and sleeps until it opens if necessary.
+@MainActor @Observable
+class JobScheduler {
+
+    // MARK: - Published state
+
+    private(set) var jobs: [ReconstructionJob] = []
+    var scheduleConfig: ScheduleConfig = ScheduleConfig()
+
+    private(set) var isRunning = false
+    private(set) var isPaused = false
+    private(set) var currentJobId: UUID?
+    private(set) var currentProgress: Double = 0
+    private(set) var estimatedTimeRemaining: TimeInterval?
+
+    // MARK: - Internal
+
+    private var processingTask: Task<Void, Never>?
+    private var currentSession: PhotogrammetrySession?
+    private let store = JobStore()
+
+    // MARK: - Persistence helpers
+
+    func persist() {
+        store.saveJobs(jobs)
+        store.saveSchedule(scheduleConfig)
+    }
+
+    func loadFromDisk() {
+        jobs = store.loadJobs()
+        scheduleConfig = store.loadSchedule()
+    }
+
+    // MARK: - Queue management
+
+    func addJob(_ job: ReconstructionJob) {
+        jobs.append(job)
+        persist()
+    }
+
+    func removeJob(_ job: ReconstructionJob) {
+        jobs.removeAll { $0.id == job.id }
+        persist()
+    }
+
+    func removeJobs(at offsets: IndexSet) {
+        jobs.remove(atOffsets: offsets)
+        persist()
+    }
+
+    func moveJob(from source: IndexSet, to destination: Int) {
+        jobs.move(fromOffsets: source, toOffset: destination)
+        persist()
+    }
+
+    func retryJob(_ job: ReconstructionJob) {
+        guard let index = jobs.firstIndex(where: { $0.id == job.id }) else { return }
+        jobs[index].status = .pending
+        jobs[index].progress = 0
+        jobs[index].errorMessage = nil
+        persist()
+    }
+
+    func updateJob(_ job: ReconstructionJob) {
+        guard let index = jobs.firstIndex(where: { $0.id == job.id }) else { return }
+        jobs[index] = job
+        persist()
+    }
+
+    var pendingJobCount: Int {
+        jobs.filter { $0.status == .pending }.count
+    }
+
+    var completedJobCount: Int {
+        jobs.filter { $0.status == .completed }.count
+    }
+
+    // MARK: - Scheduler control
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        isPaused = false
+        logger.log("Scheduler started.")
+        processingTask = Task { await processQueue() }
+    }
+
+    func pause() {
+        isPaused = true
+        logger.log("Scheduler paused.")
+    }
+
+    func resume() {
+        guard isPaused else { return }
+        isPaused = false
+        logger.log("Scheduler resumed.")
+    }
+
+    func cancel() {
+        logger.log("Scheduler cancelled.")
+        processingTask?.cancel()
+        currentSession?.cancel()
+        currentSession = nil
+        isRunning = false
+        isPaused = false
+        currentJobId = nil
+        currentProgress = 0
+        estimatedTimeRemaining = nil
+
+        // Mark the running job as cancelled.
+        if let id = currentJobId, let idx = jobs.firstIndex(where: { $0.id == id }) {
+            jobs[idx].status = .cancelled
+        }
+        persist()
+    }
+
+    // MARK: - Processing loop
+
+    private func processQueue() async {
+        defer {
+            isRunning = false
+            currentJobId = nil
+            currentProgress = 0
+            estimatedTimeRemaining = nil
+
+            let succeeded = jobs.filter { $0.status == .completed }.count
+            let failed = jobs.filter { $0.status == .failed }.count
+            sendNotification(
+                title: "Queue Complete",
+                body: "\(succeeded) succeeded, \(failed) failed"
+            )
+
+            persist()
+            logger.log("Scheduler finished.")
+        }
+
+        while !Task.isCancelled {
+            // Wait while paused.
+            while isPaused && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+            }
+            if Task.isCancelled { break }
+
+            // Wait for the allowed time window.
+            if !scheduleConfig.isWithinAllowedWindow() {
+                if let nextOpen = scheduleConfig.nextWindowOpen() {
+                    let delay = nextOpen.timeIntervalSinceNow
+                    if delay > 0 {
+                        logger.log("Outside time window. Sleeping \(Int(delay))s until \(nextOpen).")
+                        try? await Task.sleep(for: .seconds(delay))
+                        continue
+                    }
+                }
+            }
+            if Task.isCancelled { break }
+
+            // Pick the next pending job.
+            guard let index = jobs.firstIndex(where: { $0.status == .pending }) else {
+                logger.log("No more pending jobs.")
+                break
+            }
+
+            await processJob(at: index)
+        }
+    }
+
+    private func processJob(at index: Int) async {
+        let jobId = jobs[index].id
+        currentJobId = jobId
+        currentProgress = 0
+        estimatedTimeRemaining = nil
+
+        jobs[index].status = .running
+        jobs[index].progress = 0
+        persist()
+
+        let jobName = jobs[index].modelName
+        logger.log("Starting job: \(jobName) (\(jobId))")
+
+        // Resolve bookmarks for sandbox access.
+        let (imageURL, modelURL) = jobs[index].resolveBookmarks()
+        let imageAccess = imageURL?.startAccessingSecurityScopedResource() ?? false
+        let modelAccess = modelURL?.startAccessingSecurityScopedResource() ?? false
+
+        defer {
+            if imageAccess { imageURL?.stopAccessingSecurityScopedResource() }
+            if modelAccess { modelURL?.stopAccessingSecurityScopedResource() }
+        }
+
+        let config = jobs[index].sessionConfiguration.toSessionConfiguration()
+        let requests = jobs[index].createReconstructionRequests()
+
+        guard !requests.isEmpty else {
+            jobs[index].status = .failed
+            jobs[index].errorMessage = "No detail levels selected."
+            sendNotification(title: "Job Failed", body: jobName)
+            persist()
+            return
+        }
+
+        do {
+            let session = try await createSession(
+                imageFolder: jobs[index].imageFolder,
+                configuration: config
+            )
+            currentSession = session
+            try session.process(requests: requests)
+
+            // Consume session outputs.
+            for try await output in session.outputs {
+                if Task.isCancelled { break }
+                // Re-check time window between outputs.
+                if !scheduleConfig.isWithinAllowedWindow() {
+                    logger.log("Time window closed during processing. Pausing until window reopens.")
+                    while !scheduleConfig.isWithinAllowedWindow() && !Task.isCancelled {
+                        try await Task.sleep(for: .seconds(30))
+                    }
+                }
+
+                switch output {
+                case .requestProgress(_, let fraction):
+                    currentProgress = fraction
+                    if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
+                        jobs[idx].progress = fraction
+                    }
+
+                case .requestProgressInfo(_, let info):
+                    estimatedTimeRemaining = info.estimatedRemainingTime
+
+                case .requestComplete(_, _):
+                    logger.log("Request completed for job \(jobId).")
+
+                case .requestError(_, let error):
+                    logger.warning("Request error for job \(jobId): \(error)")
+
+                case .processingComplete:
+                    logger.log("Processing complete for job \(jobId).")
+
+                default:
+                    continue
+                }
+            }
+
+            currentSession = nil
+
+            if Task.isCancelled {
+                if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
+                    jobs[idx].status = .cancelled
+                }
+            } else if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
+                jobs[idx].status = .completed
+                jobs[idx].progress = 1.0
+            }
+
+        } catch {
+            logger.warning("Job \(jobId) failed: \(error)")
+            currentSession = nil
+            if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
+                jobs[idx].status = .failed
+                jobs[idx].errorMessage = "\(error)"
+            }
+            sendNotification(title: "Job Failed", body: jobName)
+        }
+
+        persist()
+    }
+
+    // MARK: - Session creation (nonisolated to avoid blocking main actor)
+
+    private nonisolated func createSession(
+        imageFolder: URL,
+        configuration: PhotogrammetrySession.Configuration
+    ) async throws -> PhotogrammetrySession {
+        logger.log("Creating PhotogrammetrySession for \(imageFolder.lastPathComponent)")
+        return try PhotogrammetrySession(input: imageFolder, configuration: configuration)
+    }
+
+    // MARK: - Notifications
+
+    private var notificationAuthorized = false
+
+    private func sendNotification(title: String, body: String) {
+        let center = UNUserNotificationCenter.current()
+
+        Task {
+            if !notificationAuthorized {
+                let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
+                notificationAuthorized = granted
+                if !granted {
+                    logger.warning("Notification permission not granted.")
+                    return
+                }
+            }
+
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil
+            )
+
+            do {
+                try await center.add(request)
+            } catch {
+                logger.warning("Failed to schedule notification: \(error)")
+            }
+        }
+    }
+}

--- a/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/AdvancedReconstructionOptions.swift
+++ b/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/AdvancedReconstructionOptions.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose customizable options on the reconstructed model and textures and process multiple detail levels.
@@ -9,10 +9,10 @@ import SwiftUI
 import RealityKit
 
 struct AdvancedReconstructionOptions: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
 
         VStack(alignment: .leading) {
             Text("Advanced Reconstruction Options")
@@ -29,22 +29,22 @@ struct AdvancedReconstructionOptions: View {
                 Divider()
                 
                 LabeledContent("Processing") {
-                    Toggle("Process multiple detail levels", isOn: $appDataModel.detailLevelOptionsUnderAdvancedMenu.isSelected)
+                    Toggle("Process multiple detail levels", isOn: $draft.detailLevelOptionsUnderAdvancedMenu.isSelected)
                 }
                 
                 Menu("Choose detail levels") {
-                    Toggle("Preview", isOn: $appDataModel.detailLevelOptionsUnderAdvancedMenu.preview)
+                    Toggle("Preview", isOn: $draft.detailLevelOptionsUnderAdvancedMenu.preview)
 
-                    Toggle("Reduced", isOn: $appDataModel.detailLevelOptionsUnderAdvancedMenu.reduced)
+                    Toggle("Reduced", isOn: $draft.detailLevelOptionsUnderAdvancedMenu.reduced)
 
-                    Toggle("Medium", isOn: $appDataModel.detailLevelOptionsUnderAdvancedMenu.medium)
+                    Toggle("Medium", isOn: $draft.detailLevelOptionsUnderAdvancedMenu.medium)
 
-                    Toggle("Full", isOn: $appDataModel.detailLevelOptionsUnderAdvancedMenu.full)
+                    Toggle("Full", isOn: $draft.detailLevelOptionsUnderAdvancedMenu.full)
 
-                    Toggle("Raw", isOn: $appDataModel.detailLevelOptionsUnderAdvancedMenu.raw)
+                    Toggle("Raw", isOn: $draft.detailLevelOptionsUnderAdvancedMenu.raw)
 
                 }
-                .disabled(!appDataModel.detailLevelOptionsUnderAdvancedMenu.isSelected)
+                .disabled(!draft.detailLevelOptionsUnderAdvancedMenu.isSelected)
             }
         }
         .padding()

--- a/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/PolygonCountView.swift
+++ b/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/PolygonCountView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Set the upper limit on polygons in the model mesh.
@@ -9,17 +9,17 @@ import SwiftUI
 import RealityKit
 
 struct PolygonCountView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
 
         LabeledContent("Max Polygon Count:") {
-            TextField("", value: $appDataModel.sessionConfiguration.customDetailSpecification.maximumPolygonCount, formatter: NumberFormatter())
+            TextField("", value: $draft.sessionConfiguration.customDetailSpecification.maximumPolygonCount, formatter: NumberFormatter())
                 .textFieldStyle(.roundedBorder)
         }
-        .onChange(of: appDataModel.sessionConfiguration.customDetailSpecification.maximumPolygonCount, initial: false) {
-            appDataModel.detailLevelOptionUnderQualityMenu = .custom
+        .onChange(of: draft.sessionConfiguration.customDetailSpecification.maximumPolygonCount, initial: false) {
+            draft.detailLevelOptionUnderQualityMenu = .custom
         }
     }
 }

--- a/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/TextureFormatView.swift
+++ b/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/TextureFormatView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the output format to use for all textures.
@@ -9,20 +9,20 @@ import SwiftUI
 import RealityKit
 
 struct TextureFormatView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
 
-        Picker("Texture Format:", selection: $appDataModel.sessionConfiguration.customDetailSpecification.textureFormat) {
+        Picker("Texture Format:", selection: $draft.sessionConfiguration.customDetailSpecification.textureFormat) {
             Text("PNG")
                 .tag(PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureFormat.png)
             
             Text("JPEG")
                 .tag(PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureFormat.jpeg(compressionQuality: 0.8))
         }
-        .onChange(of: appDataModel.sessionConfiguration.customDetailSpecification.textureFormat) {
-            appDataModel.detailLevelOptionUnderQualityMenu = .custom
+        .onChange(of: draft.sessionConfiguration.customDetailSpecification.textureFormat) {
+            draft.detailLevelOptionUnderQualityMenu = .custom
         }
     }
 }

--- a/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/TextureMapsView.swift
+++ b/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/TextureMapsView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the output texture maps to include in the output model.
@@ -9,7 +9,7 @@ import SwiftUI
 import RealityKit
 
 struct TextureMapsView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var selectedTextureMap = PhotogrammetrySession.Configuration.CustomDetailSpecification().outputTextureMaps.rawValue
 
     var body: some View {
@@ -34,11 +34,11 @@ struct TextureMapsView: View {
         }
         .onChange(of: selectedTextureMap, initial: false) {
             let newValue = PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureMapOutputs(rawValue: selectedTextureMap)
-            appDataModel.sessionConfiguration.customDetailSpecification.outputTextureMaps = newValue
-            appDataModel.detailLevelOptionUnderQualityMenu = .custom
+            draft.sessionConfiguration.customDetailSpecification.outputTextureMaps = newValue
+            draft.detailLevelOptionUnderQualityMenu = .custom
         }
         .onAppear {
-            selectedTextureMap = appDataModel.sessionConfiguration.customDetailSpecification.outputTextureMaps.rawValue
+            selectedTextureMap = draft.sessionConfiguration.customDetailSpecification.outputTextureMaps.rawValue
         }
     }
 }

--- a/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/TextureResolutionView.swift
+++ b/ObjectCaptureReconstruction/Settings/AdvancedReconstructionOptions/TextureResolutionView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the maximum dimension of the reconstructed texture maps.
@@ -9,12 +9,12 @@ import SwiftUI
 import RealityKit
 
 struct TextureResolutionView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
  
-        Picker("Texture Resolution:", selection: $appDataModel.sessionConfiguration.customDetailSpecification.maximumTextureDimension) {
+        Picker("Texture Resolution:", selection: $draft.sessionConfiguration.customDetailSpecification.maximumTextureDimension) {
             Text("1K")
                 .tag(PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureDimension.oneK)
             
@@ -30,8 +30,8 @@ struct TextureResolutionView: View {
             Text("16K")
                 .tag(PhotogrammetrySession.Configuration.CustomDetailSpecification.TextureDimension.sixteenK)
         }
-        .onChange(of: appDataModel.sessionConfiguration.customDetailSpecification.maximumTextureDimension, initial: false) {
-            appDataModel.detailLevelOptionUnderQualityMenu = .custom
+        .onChange(of: draft.sessionConfiguration.customDetailSpecification.maximumTextureDimension, initial: false) {
+            draft.detailLevelOptionUnderQualityMenu = .custom
         }
     }
 }

--- a/ObjectCaptureReconstruction/Settings/FolderOptions/FolderOptionsView.swift
+++ b/ObjectCaptureReconstruction/Settings/FolderOptions/FolderOptionsView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the image folder, model folder, and the model name.
@@ -9,8 +9,6 @@ import SwiftUI
 import RealityKit
 
 struct FolderOptionsView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
-
     var body: some View {
         Section {
             ImageFolderView()

--- a/ObjectCaptureReconstruction/Settings/FolderOptions/ImageFolderSelectionView.swift
+++ b/ObjectCaptureReconstruction/Settings/FolderOptions/ImageFolderSelectionView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the image folder.
@@ -14,7 +14,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
 struct ImageFolderSelectionView: View {
     @Binding var selectedFolder: URL?
 
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var showFileImporter = false
 
     var body: some View {
@@ -46,8 +46,8 @@ struct ImageFolderSelectionView: View {
                 if !gotAccess { return }
                 selectedFolder = directory
             case .failure(let error):
-                appDataModel.alertMessage = "\(error)"
-                appDataModel.state = .error
+                draft.alertMessage = "\(error)"
+                draft.hasError = true
             }
         }
 

--- a/ObjectCaptureReconstruction/Settings/FolderOptions/ImageFolderView.swift
+++ b/ObjectCaptureReconstruction/Settings/FolderOptions/ImageFolderView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the image folder.
@@ -13,7 +13,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
                             category: "ImageFolderView")
 
 struct ImageFolderView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var selectedFolder: URL?
     @State private var imageURLs: [URL] = []
     @State private var numImages: Int?
@@ -57,14 +57,14 @@ struct ImageFolderView: View {
             .background(Color.gray.opacity(0.1))
             .cornerRadius(10)
             .onAppear {
-                selectedFolder = appDataModel.imageFolder
+                selectedFolder = draft.imageFolder
             }
         }
         .frame(height: 110)
         .onChange(of: selectedFolder) {
-            appDataModel.boundingBoxAvailable = false
+            draft.boundingBoxAvailable = false
             metadataAvailability = ImageHelper.MetadataAvailability()
-            appDataModel.imageFolder = selectedFolder
+            draft.imageFolder = selectedFolder
         }
         .dropDestination(for: URL.self) { items, location in
             guard !items.isEmpty else { return false }
@@ -83,23 +83,22 @@ struct ImageFolderView: View {
                 numImages = nil
                 imageURLs = []
                 metadataAvailability = ImageHelper.MetadataAvailability()
-                appDataModel.boundingBoxAvailable = false
+                draft.boundingBoxAvailable = false
                 return
             }
 
             imageURLs = ImageHelper.getListOfURLs(from: selectedFolder)
             if imageURLs.isEmpty {
-                appDataModel.state = .error
-                appDataModel.alertMessage = "\(String(describing: PhotogrammetrySession.Error.invalidImages(selectedFolder)))"
+                draft.hasError = true
+                draft.alertMessage = "\(String(describing: PhotogrammetrySession.Error.invalidImages(selectedFolder)))"
                 self.selectedFolder = nil
                 return
             }
 
             numImages = imageURLs.count
 
-            // Check whether enough metadata is available.
             metadataAvailability = await ImageHelper.loadMetadataAvailability(from: imageURLs)
-            appDataModel.boundingBoxAvailable = metadataAvailability.boundingBox
+            draft.boundingBoxAvailable = metadataAvailability.boundingBox
         }
     }
 

--- a/ObjectCaptureReconstruction/Settings/FolderOptions/ModelFolderView.swift
+++ b/ObjectCaptureReconstruction/Settings/FolderOptions/ModelFolderView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the folder for storing the created models.
@@ -8,7 +8,7 @@ Choose the folder for storing the created models.
 import SwiftUI
 
 struct ModelFolderView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var showFileImporter = false
 
     var body: some View {
@@ -17,7 +17,7 @@ struct ModelFolderView: View {
                 showFileImporter.toggle()
             } label: {
                 HStack {
-                    if let selectedFolder = appDataModel.modelFolder {
+                    if let selectedFolder = draft.modelFolder {
                         HStack {
                             Image(nsImage: NSWorkspace.shared.icon(for: .folder))
                                 .resizable()
@@ -37,10 +37,10 @@ struct ModelFolderView: View {
                 case .success(let directory):
                     let gotAccess = directory.startAccessingSecurityScopedResource()
                     if !gotAccess { return }
-                    appDataModel.modelFolder = directory
+                    draft.modelFolder = directory
                 case .failure(let error):
-                    appDataModel.alertMessage = "\(error)"
-                    appDataModel.state = .error
+                    draft.alertMessage = "\(error)"
+                    draft.hasError = true
                 }
             }
         }

--- a/ObjectCaptureReconstruction/Settings/FolderOptions/ModelNameField.swift
+++ b/ObjectCaptureReconstruction/Settings/FolderOptions/ModelNameField.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the model name for the created USDZ file.
@@ -8,7 +8,7 @@ Choose the model name for the created USDZ file.
 import SwiftUI
 
 struct ModelNameField: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var modelName: String = ""
 
     var body: some View {
@@ -18,14 +18,14 @@ struct ModelNameField: View {
         }
         .onChange(of: modelName) {
             if !modelName.isEmpty {
-                appDataModel.modelName = modelName
+                draft.modelName = modelName
             } else {
-                appDataModel.modelName = nil
+                draft.modelName = nil
             }
         }
         .onAppear {
-            guard let appModelName = appDataModel.modelName else { return }
-            modelName = appModelName
+            guard let name = draft.modelName else { return }
+            modelName = name
         }
     }
 }

--- a/ObjectCaptureReconstruction/Settings/ProcessButton/ProcessButton.swift
+++ b/ObjectCaptureReconstruction/Settings/ProcessButton/ProcessButton.swift
@@ -1,8 +1,8 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
-Provide a button to start the reconstruction.
+Provide a button to add the configured job to the queue.
 */
 
 import SwiftUI
@@ -12,23 +12,35 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
                             category: "ProcessButton")
 
 struct ProcessButton: View {
+    @Environment(JobDraft.self) private var draft: JobDraft
     @Environment(AppDataModel.self) private var appDataModel: AppDataModel
-    // Indicates if the button is pressed.
-    @State private var processing = false
+    @Environment(\.dismiss) private var dismiss
+
+    var isEditing: Bool = false
 
     var body: some View {
         HStack {
-            Spacer()
-            Button("Process") {
-                if !processing {
-                    processing = true
-                    logger.log("Process button clicked!")
-                    Task {
-                        await appDataModel.startReconstruction()
-                    }
-                }
+            Button("Cancel") {
+                dismiss()
             }
-            .disabled(processing)
+
+            Spacer()
+
+            Button(isEditing ? "Save Changes" : "Add to Queue") {
+                guard draft.validate() else { return }
+                guard let job = draft.toJob() else { return }
+                logger.log("Adding job to queue: \(job.modelName)")
+
+                if isEditing, let editingJob = appDataModel.editingJob {
+                    var updatedJob = job
+                    updatedJob.status = editingJob.status
+                    appDataModel.scheduler.updateJob(updatedJob)
+                } else {
+                    appDataModel.scheduler.addJob(job)
+                }
+
+                dismiss()
+            }
         }
         .padding(.top, 3)
     }

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/IgnoreBoundingBoxView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/IgnoreBoundingBoxView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Option to ignore the iOS bounding box during reconstruction.
@@ -9,14 +9,14 @@ import SwiftUI
 import RealityKit
 
 struct IgnoreBoundingBoxView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
         
         LabeledContent("Crop:") {
-            Toggle("Ignore iOS bounding box", isOn: $appDataModel.sessionConfiguration.ignoreBoundingBox)
+            Toggle("Ignore iOS bounding box", isOn: $draft.sessionConfiguration.ignoreBoundingBox)
         }
-        .disabled(!appDataModel.boundingBoxAvailable)
+        .disabled(!draft.boundingBoxAvailable)
     }
 }

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/MaskingView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/MaskingView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Option to isolate the object or to include the environment in the created model.
@@ -9,7 +9,7 @@ import SwiftUI
 import RealityKit
 
 struct MaskingView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var selectedMaskOption = MaskingOption.isolateFromEnvironment
 
     var body: some View {
@@ -24,13 +24,13 @@ struct MaskingView: View {
         .onChange(of: selectedMaskOption, initial: false) {
             switch selectedMaskOption {
             case .isolateFromEnvironment:
-                appDataModel.sessionConfiguration.isObjectMaskingEnabled = true
+                draft.sessionConfiguration.isObjectMaskingEnabled = true
             case .includeEnvironment:
-                appDataModel.sessionConfiguration.isObjectMaskingEnabled = false
+                draft.sessionConfiguration.isObjectMaskingEnabled = false
             }
         }
         .onAppear {
-            if appDataModel.sessionConfiguration.isObjectMaskingEnabled {
+            if draft.sessionConfiguration.isObjectMaskingEnabled {
                 selectedMaskOption = .isolateFromEnvironment
             } else {
                 selectedMaskOption = .includeEnvironment

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/MeshTypeView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/MeshTypeView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Select the mesh type of the created model.
@@ -9,12 +9,12 @@ import SwiftUI
 import RealityKit
 
 struct MeshTypeView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
         
-        Picker("Mesh Type:", selection: $appDataModel.sessionConfiguration.meshPrimitive) {
+        Picker("Mesh Type:", selection: $draft.sessionConfiguration.meshPrimitive) {
             Text("Triangular Mesh")
                 .tag(PhotogrammetrySession.Configuration.MeshPrimitive.triangle)
             

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/QualityView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/QualityView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the level of detail for the created model.
@@ -9,14 +9,14 @@ import SwiftUI
 import RealityKit
 
 struct QualityView: View {
-    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    @Environment(JobDraft.self) private var draft: JobDraft
     @State private var showAdvancedOptions = false
 
     var body: some View {
-        @Bindable var appDataModel = appDataModel
+        @Bindable var draft = draft
         
         HStack {
-            Picker("Quality:", selection: $appDataModel.detailLevelOptionUnderQualityMenu) {
+            Picker("Quality:", selection: $draft.detailLevelOptionUnderQualityMenu) {
                 Text("Preview")
                     .tag(RealityFoundation.PhotogrammetrySession.Request.Detail.preview)
                 
@@ -46,9 +46,9 @@ struct QualityView: View {
         .popover(isPresented: $showAdvancedOptions) {
             AdvancedReconstructionOptions()
         }
-        .onChange(of: appDataModel.detailLevelOptionUnderQualityMenu) {
-            if appDataModel.detailLevelOptionUnderQualityMenu != .custom {
-                appDataModel.sessionConfiguration.customDetailSpecification = PhotogrammetrySession.Configuration.CustomDetailSpecification()
+        .onChange(of: draft.detailLevelOptionUnderQualityMenu) {
+            if draft.detailLevelOptionUnderQualityMenu != .custom {
+                draft.sessionConfiguration.customDetailSpecification = PhotogrammetrySession.Configuration.CustomDetailSpecification()
             }
         }
     }

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ReconstructionOptionsView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ReconstructionOptionsView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Reconstruction options.

--- a/ObjectCaptureReconstruction/Settings/SettingsView.swift
+++ b/ObjectCaptureReconstruction/Settings/SettingsView.swift
@@ -1,5 +1,5 @@
 /*
-See the LICENSE.txt file for this sample’s licensing information.
+See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
 Choose the image and model folders, the model name, and the reconstruction options.
@@ -26,11 +26,6 @@ struct SettingsView: View {
                 ReconstructionOptionsView()
             }
             .padding(.leading, 13)
-            
-            Divider()
-                .padding(.horizontal, -20)
-            
-            ProcessButton()
         }
     }
 }

--- a/ObjectCaptureReconstruction/Store/JobStore.swift
+++ b/ObjectCaptureReconstruction/Store/JobStore.swift
@@ -1,0 +1,89 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Persistence layer for saving and loading the job queue and schedule to disk.
+*/
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "JobStore")
+
+/// Saves and loads `[ReconstructionJob]` and `ScheduleConfig` as JSON files
+/// in the app's Application Support directory.
+@MainActor
+class JobStore {
+
+    private let jobsFileURL: URL
+    private let scheduleFileURL: URL
+
+    init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let storeDir = appSupport.appending(path: "ObjectCaptureReconstruction")
+
+        // Ensure the directory exists.
+        try? FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
+
+        jobsFileURL = storeDir.appending(path: "jobs.json")
+        scheduleFileURL = storeDir.appending(path: "schedule.json")
+    }
+
+    // MARK: - Jobs
+
+    func saveJobs(_ jobs: [ReconstructionJob]) {
+        do {
+            let data = try JSONEncoder().encode(jobs)
+            try data.write(to: jobsFileURL, options: .atomic)
+            logger.log("Saved \(jobs.count) job(s) to disk.")
+        } catch {
+            logger.warning("Failed to save jobs: \(error)")
+        }
+    }
+
+    func loadJobs() -> [ReconstructionJob] {
+        guard FileManager.default.fileExists(atPath: jobsFileURL.path()) else { return [] }
+        do {
+            let data = try Data(contentsOf: jobsFileURL)
+            var jobs = try JSONDecoder().decode([ReconstructionJob].self, from: data)
+
+            // Resolve security-scoped bookmarks and reset any stale running state.
+            for index in jobs.indices {
+                _ = jobs[index].resolveBookmarks()
+                if jobs[index].status == .running {
+                    jobs[index].status = .pending
+                    jobs[index].progress = 0
+                }
+            }
+
+            logger.log("Loaded \(jobs.count) job(s) from disk.")
+            return jobs
+        } catch {
+            logger.warning("Failed to load jobs: \(error)")
+            return []
+        }
+    }
+
+    // MARK: - Schedule
+
+    func saveSchedule(_ config: ScheduleConfig) {
+        do {
+            let data = try JSONEncoder().encode(config)
+            try data.write(to: scheduleFileURL, options: .atomic)
+        } catch {
+            logger.warning("Failed to save schedule: \(error)")
+        }
+    }
+
+    func loadSchedule() -> ScheduleConfig {
+        guard FileManager.default.fileExists(atPath: scheduleFileURL.path()) else { return ScheduleConfig() }
+        do {
+            let data = try Data(contentsOf: scheduleFileURL)
+            return try JSONDecoder().decode(ScheduleConfig.self, from: data)
+        } catch {
+            logger.warning("Failed to load schedule: \(error)")
+            return ScheduleConfig()
+        }
+    }
+}


### PR DESCRIPTION
Transform single-session Object Capture app into a batch queue system:

- Add ReconstructionJob, ScheduleConfig, CodableSessionConfiguration data models
- Add JobScheduler for sequential job processing with time-window support
- Add JobStore for JSON persistence with security-scoped bookmarks
- Add JobDraft observable class bridging Codable models and live UI bindings
- Add QueueDashboardView, JobRowView, JobSetupView, ScheduleSettingsView
- Refactor all Settings views from @Environment(AppDataModel) to @Environment(JobDraft)
- Refactor AppDataModel to hold JobScheduler instead of single-session state
- Refactor ContentView to show queue dashboard with sheet-based job setup
- Make window resizable (700x500 minimum)
- Add local notifications for queue completion and job failures
- Remove old Processing views from build (dead code)