### PR TITLE
🐛 Detect premature session termination

### DIFF
--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -222,9 +222,10 @@ class JobScheduler {
             )
             currentSession = session
             try session.process(requests: requests)
+            var didReceiveProcessingComplete = false
 
             // Consume session outputs.
-            for try await output in session.outputs {
+            outputLoop: for try await output in session.outputs {
                 if Task.isCancelled { break }
                 // Re-check time window between outputs.
                 if !scheduleConfig.isWithinAllowedWindow() {
@@ -252,6 +253,13 @@ class JobScheduler {
 
                 case .processingComplete:
                     logger.log("Processing complete for job \(jobId).")
+                    didReceiveProcessingComplete = true
+                    currentProgress = 1.0
+                    estimatedTimeRemaining = nil
+                    if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
+                        jobs[idx].progress = 1.0
+                    }
+                    break outputLoop
 
                 default:
                     continue
@@ -263,6 +271,12 @@ class JobScheduler {
             if Task.isCancelled {
                 if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
                     jobs[idx].status = .cancelled
+                }
+            } else if !didReceiveProcessingComplete {
+                logger.warning("Session output ended before processingComplete for job \(jobId).")
+                if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
+                    jobs[idx].status = .failed
+                    jobs[idx].errorMessage = "Processing ended before completion signal."
                 }
             } else if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
                 jobs[idx].status = .completed


### PR DESCRIPTION
Add handling for sessions whose outputs end without a processingComplete event. Introduces a didReceiveProcessingComplete flag and a labeled output loop; when .processingComplete is received the job progress is set to 1.0 and the estimated time is cleared. If the session output stream ends without the completion signal, log a warning and mark the job as failed with an error message so jobs aren't left in an indeterminate state.