### PR TITLE
💄 Update UI for pause

### DIFF
--- a/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
+++ b/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
@@ -93,54 +93,68 @@ struct QueueDashboardView: View {
 
 private struct QueueHeaderView: View {
     @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+    
+    private var scheduler: JobScheduler {
+        appDataModel.scheduler
+    }
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
                 Text("Job Queue")
                     .font(.headline)
 
                 Text(statusSummary)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if scheduler.isRunning {
+                    if scheduler.isPaused || scheduler.isPauseRequested {
+                        Button("Resume") {
+                            scheduler.resume()
+                        }
+                    } else {
+                        Button(pauseButtonTitle) {
+                            scheduler.pause()
+                        }
+                    }
+
+                    Button("Stop") {
+                        scheduler.cancel()
+                    }
+                    .foregroundStyle(.red)
+                } else if scheduler.pendingJobCount > 0 {
+                    Button("Start") {
+                        scheduler.start()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
             }
 
-            Spacer()
-
-            if appDataModel.scheduler.isRunning {
-                if appDataModel.scheduler.isPaused {
-                    Button("Resume") {
-                        appDataModel.scheduler.resume()
-                    }
-                } else {
-                    Button("Pause") {
-                        appDataModel.scheduler.pause()
-                    }
-                }
-
-                Button("Stop") {
-                    appDataModel.scheduler.cancel()
-                }
-                .foregroundStyle(.red)
-            } else if appDataModel.scheduler.pendingJobCount > 0 {
-                Button("Start") {
-                    appDataModel.scheduler.start()
-                }
-                .buttonStyle(.borderedProminent)
+            if let pauseExplanation {
+                Text(pauseExplanation)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
         }
         .padding()
     }
 
     private var statusSummary: String {
-        let scheduler = appDataModel.scheduler
         let total = scheduler.jobs.count
         let completed = scheduler.completedJobCount
         let pending = scheduler.pendingJobCount
 
         if scheduler.isRunning {
             if scheduler.isPaused {
-                return "Paused — \(completed)/\(total) complete"
+                return "Queue paused between jobs — \(completed)/\(total) complete"
+            }
+            if scheduler.isPauseRequested {
+                return "Pause requested — current job will finish before stopping"
             }
             return "Processing — \(completed)/\(total) complete"
         }
@@ -148,6 +162,22 @@ private struct QueueHeaderView: View {
         if total == 0 { return "Empty" }
         if pending == 0 && completed == total { return "All \(total) jobs complete" }
         return "\(pending) pending, \(completed) complete"
+    }
+
+    private var pauseButtonTitle: String {
+        scheduler.currentJobId == nil ? "Pause" : "Pause After Job"
+    }
+
+    private var pauseExplanation: String? {
+        if scheduler.isPauseRequested {
+            return "Apple Object Capture does not support pausing an in-progress reconstruction. The queue will stop before the next job starts."
+        }
+
+        if scheduler.isRunning && scheduler.currentJobId != nil {
+            return "Pausing takes effect between jobs only. If the schedule window closes mid-job, the active reconstruction continues until it completes or is cancelled."
+        }
+
+        return nil
     }
 }
 

--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -26,6 +26,7 @@ class JobScheduler {
 
     private(set) var isRunning = false
     private(set) var isPaused = false
+    private(set) var isPauseRequested = false
     private(set) var currentJobId: UUID?
     private(set) var currentProgress: Double = 0
     private(set) var estimatedTimeRemaining: TimeInterval?
@@ -98,34 +99,53 @@ class JobScheduler {
         guard !isRunning else { return }
         isRunning = true
         isPaused = false
+        isPauseRequested = false
         logger.log("Scheduler started.")
         processingTask = Task { await processQueue() }
     }
 
     func pause() {
-        isPaused = true
-        logger.log("Scheduler paused.")
+        guard isRunning else { return }
+        guard !isPaused && !isPauseRequested else { return }
+
+        if currentJobId != nil {
+            isPauseRequested = true
+            logger.log("Pause requested. Current job will continue until completion because PhotogrammetrySession does not support pausing.")
+        } else {
+            isPaused = true
+            logger.log("Scheduler paused between jobs.")
+        }
     }
 
     func resume() {
-        guard isPaused else { return }
-        isPaused = false
-        logger.log("Scheduler resumed.")
+        guard isPaused || isPauseRequested else { return }
+
+        let hadPendingPauseRequest = isPauseRequested
+        isPauseRequested = false
+
+        if isPaused {
+            isPaused = false
+            logger.log("Scheduler resumed.")
+        } else if hadPendingPauseRequest {
+            logger.log("Pending pause request cleared.")
+        }
     }
 
     func cancel() {
         logger.log("Scheduler cancelled.")
+        let cancellingJobId = currentJobId
         processingTask?.cancel()
         currentSession?.cancel()
         currentSession = nil
         isRunning = false
         isPaused = false
+        isPauseRequested = false
         currentJobId = nil
         currentProgress = 0
         estimatedTimeRemaining = nil
 
         // Mark the running job as cancelled.
-        if let id = currentJobId, let idx = jobs.firstIndex(where: { $0.id == id }) {
+        if let id = cancellingJobId, let idx = jobs.firstIndex(where: { $0.id == id }) {
             jobs[idx].status = .cancelled
         }
         persist()
@@ -152,6 +172,8 @@ class JobScheduler {
         }
 
         while !Task.isCancelled {
+            activatePauseIfNeeded()
+
             // Wait while paused.
             while isPaused && !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(1))
@@ -171,6 +193,9 @@ class JobScheduler {
             }
             if Task.isCancelled { break }
 
+            activatePauseIfNeeded()
+            if isPaused { continue }
+
             // Pick the next pending job.
             guard let index = jobs.firstIndex(where: { $0.status == .pending }) else {
                 logger.log("No more pending jobs.")
@@ -186,6 +211,7 @@ class JobScheduler {
         currentJobId = jobId
         currentProgress = 0
         estimatedTimeRemaining = nil
+        var loggedWindowClosureDuringActiveJob = false
 
         jobs[index].status = .running
         jobs[index].progress = 0
@@ -227,12 +253,9 @@ class JobScheduler {
             // Consume session outputs.
             outputLoop: for try await output in session.outputs {
                 if Task.isCancelled { break }
-                // Re-check time window between outputs.
-                if !scheduleConfig.isWithinAllowedWindow() {
-                    logger.log("Time window closed during processing. Pausing until window reopens.")
-                    while !scheduleConfig.isWithinAllowedWindow() && !Task.isCancelled {
-                        try await Task.sleep(for: .seconds(30))
-                    }
+                if !scheduleConfig.isWithinAllowedWindow() && !loggedWindowClosureDuringActiveJob {
+                    logger.log("Allowed time window closed during processing. Continuing the active job because PhotogrammetrySession does not support pausing.")
+                    loggedWindowClosureDuringActiveJob = true
                 }
 
                 switch output {
@@ -293,7 +316,15 @@ class JobScheduler {
             sendNotification(title: "Job Failed", body: jobName)
         }
 
+        currentJobId = nil
         persist()
+    }
+
+    private func activatePauseIfNeeded() {
+        guard isPauseRequested, currentJobId == nil else { return }
+        isPauseRequested = false
+        isPaused = true
+        logger.log("Scheduler paused between jobs.")
     }
 
     // MARK: - Session creation (nonisolated to avoid blocking main actor)


### PR DESCRIPTION
Introduce a pause-requested state and wire it through the scheduler and UI. JobScheduler: add isPauseRequested, set it when pause() is called during an active job, clear it on resume(), and activate a real paused state between jobs via activatePauseIfNeeded(). Ensure cancel() clears the pause request and correctly marks the cancelled job. Improve logging around pause requests and when the allowed time window closes during an active job. QueueDashboardView: expose scheduler via the environment, update header layout and controls to show Resume / Pause / Pause After Job / Stop / Start appropriately, show contextual explanations for pause behavior, and update status text to reflect pause-requested state. Small UI spacing and wording tweaks to make the pause semantics clearer to users.