### PR TITLE
Add glTF and GLB export support

### DIFF
--- a/ObjectCaptureReconstruction.xcodeproj/project.pbxproj
+++ b/ObjectCaptureReconstruction.xcodeproj/project.pbxproj
@@ -7,32 +7,47 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05E9773251F45705785EB1EC /* QueueDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */; };
+		0DA909603009039BB1FEB542 /* JobDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */; };
 		26B0954B2C091C770097324A /* ThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B0954A2C091C770097324A /* ThumbnailView.swift */; };
+		4A09793D6E37710A3E5C6A9E /* CodableSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */; };
+		4A45C797C462E066F321F944 /* JobScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5722048B055E10C8C4635BA /* JobScheduler.swift */; };
+		4FEA8298C11A586715309B27 /* ReconstructionJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */; };
+		5B7275D8B81A2AA37B5D76A1 /* ScheduleSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */; };
+		5BB43283ED23CAD514525CCE /* ScheduleConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */; };
+		665189C5915C218406A40D61 /* JobRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE344691F76FD3CE82E7FCF /* JobRowView.swift */; };
+		8EDA871038ABBECE6E11AF17 /* JobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4F782DCEACB71739E8182 /* JobStore.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* VideoHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* VideoHelper.swift */; };
+		C0A7E6000010000000000001 /* ModelExportFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A7E6000010000000000002 /* ModelExportFormat.swift */; };
+		C0A7E6000010000000000003 /* OBJToGLTFConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A7E6000010000000000004 /* OBJToGLTFConverter.swift */; };
+		DC9509AE8DE723BBD01EC86D /* JobSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */; };
 		F974D11A2BE0484500EFACBA /* ObjectCaptureReconstructionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D1192BE0484500EFACBA /* ObjectCaptureReconstructionApp.swift */; };
 		F974D11C2BE0484500EFACBA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D11B2BE0484500EFACBA /* ContentView.swift */; };
 		F974D11E2BE0484700EFACBA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F974D11D2BE0484700EFACBA /* Assets.xcassets */; };
 		F974D56A2BE1BCB600EFACBA /* AppDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F974D5692BE1BCB600EFACBA /* AppDataModel.swift */; };
 		F9D806832BFE6EA1005A4B94 /* ImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D806822BFE6EA1005A4B94 /* ImageHelper.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* VideoHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* VideoHelper.swift */; };
-		4A09793D6E37710A3E5C6A9E /* CodableSessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */; };
-		4FEA8298C11A586715309B27 /* ReconstructionJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */; };
-		5BB43283ED23CAD514525CCE /* ScheduleConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */; };
-		0DA909603009039BB1FEB542 /* JobDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */; };
-		4A45C797C462E066F321F944 /* JobScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5722048B055E10C8C4635BA /* JobScheduler.swift */; };
-		8EDA871038ABBECE6E11AF17 /* JobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4F782DCEACB71739E8182 /* JobStore.swift */; };
-		05E9773251F45705785EB1EC /* QueueDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */; };
-		665189C5915C218406A40D61 /* JobRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE344691F76FD3CE82E7FCF /* JobRowView.swift */; };
-		DC9509AE8DE723BBD01EC86D /* JobSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */; };
-		5B7275D8B81A2AA37B5D76A1 /* ScheduleSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		26B095462C091BC80097324A /* TopBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarView.swift; sourceTree = "<group>"; };
 		26B095482C091BEA0097324A /* BottomBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomBarView.swift; sourceTree = "<group>"; };
 		26B0954A2C091C770097324A /* ThumbnailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailView.swift; sourceTree = "<group>"; };
+		33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobSetupView.swift; sourceTree = "<group>"; };
+		37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleSettingsView.swift; sourceTree = "<group>"; };
 		3C5F7AF546F9B84B57A6DCB2 /* LICENSE.txt */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableSessionConfiguration.swift; sourceTree = "<group>"; };
 		79ACD3BEE87FD0408B1A71F5 /* SampleCode.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = SampleCode.xcconfig; path = Configuration/SampleCode.xcconfig; sourceTree = "<group>"; };
+		958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleConfig.swift; sourceTree = "<group>"; };
 		971147DC9E6FE3FF0398B220 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A7B8C9D0E1F3 /* VideoHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoHelper.swift; sourceTree = "<group>"; };
+		A5722048B055E10C8C4635BA /* JobScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobScheduler.swift; sourceTree = "<group>"; };
+		AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconstructionJob.swift; sourceTree = "<group>"; };
+		B0C4F782DCEACB71739E8182 /* JobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobStore.swift; sourceTree = "<group>"; };
+		B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueDashboardView.swift; sourceTree = "<group>"; };
+		BCE344691F76FD3CE82E7FCF /* JobRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobRowView.swift; sourceTree = "<group>"; };
+		C0A7E6000010000000000002 /* ModelExportFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelExportFormat.swift; sourceTree = "<group>"; };
+		C0A7E6000010000000000004 /* OBJToGLTFConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OBJToGLTFConverter.swift; sourceTree = "<group>"; };
+		E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDraft.swift; sourceTree = "<group>"; };
 		F974D1162BE0484500EFACBA /* Object Capture Reconstruction.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Object Capture Reconstruction.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F974D1192BE0484500EFACBA /* ObjectCaptureReconstructionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectCaptureReconstructionApp.swift; sourceTree = "<group>"; };
 		F974D11B2BE0484500EFACBA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -41,19 +56,8 @@
 		F974D56B2BE1CF0600EFACBA /* ProcessingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessingView.swift; sourceTree = "<group>"; };
 		F99368C22BE3118600DAA789 /* ModelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelView.swift; sourceTree = "<group>"; };
 		F9D806822BFE6EA1005A4B94 /* ImageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHelper.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6A7B8C9D0E1F3 /* VideoHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoHelper.swift; sourceTree = "<group>"; };
 		F9F1BEDA2C6433340066F3D3 /* ReconstructionProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconstructionProgressView.swift; sourceTree = "<group>"; };
 		F9F1BEDB2C6433340066F3D3 /* ReprocessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReprocessView.swift; sourceTree = "<group>"; };
-		5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableSessionConfiguration.swift; sourceTree = "<group>"; };
-		AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconstructionJob.swift; sourceTree = "<group>"; };
-		958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleConfig.swift; sourceTree = "<group>"; };
-		E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobDraft.swift; sourceTree = "<group>"; };
-		A5722048B055E10C8C4635BA /* JobScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobScheduler.swift; sourceTree = "<group>"; };
-		B0C4F782DCEACB71739E8182 /* JobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobStore.swift; sourceTree = "<group>"; };
-		B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueDashboardView.swift; sourceTree = "<group>"; };
-		BCE344691F76FD3CE82E7FCF /* JobRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobRowView.swift; sourceTree = "<group>"; };
-		33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobSetupView.swift; sourceTree = "<group>"; };
-		37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleSettingsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -73,6 +77,7 @@
 				FolderOptions/ModelNameField.swift,
 				FolderOptions/VideoInputView.swift,
 				ProcessButton/ProcessButton.swift,
+				ReconstructionOptions/ExportFormatView.swift,
 				ReconstructionOptions/IgnoreBoundingBoxView.swift,
 				ReconstructionOptions/MaskingView.swift,
 				ReconstructionOptions/MeshTypeView.swift,
@@ -101,6 +106,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		195BAF6352F89DD77AFC2745 /* Store */ = {
+			isa = PBXGroup;
+			children = (
+				B0C4F782DCEACB71739E8182 /* JobStore.swift */,
+			);
+			path = Store;
+			sourceTree = "<group>";
+		};
 		26B095232C091B810097324A /* Processing */ = {
 			isa = PBXGroup;
 			children = (
@@ -114,12 +127,43 @@
 			path = Processing;
 			sourceTree = "<group>";
 		};
+		992CB303C65294FA4C0E9608 /* Scheduler */ = {
+			isa = PBXGroup;
+			children = (
+				A5722048B055E10C8C4635BA /* JobScheduler.swift */,
+			);
+			path = Scheduler;
+			sourceTree = "<group>";
+		};
+		AAC7DC5DCD23638D271D3093 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5A00FFF0EB8B4E921061918F /* CodableSessionConfiguration.swift */,
+				AFC5AB62125CB98EAA9DF3F6 /* ReconstructionJob.swift */,
+				958B6CDE5F744C8A9E27719D /* ScheduleConfig.swift */,
+				E3A4F851B39B9C4EA08E7C13 /* JobDraft.swift */,
+				C0A7E6000010000000000002 /* ModelExportFormat.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		BD87F13DD4B2159CCB69FFA2 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
 				79ACD3BEE87FD0408B1A71F5 /* SampleCode.xcconfig */,
 			);
 			name = Configuration;
+			sourceTree = "<group>";
+		};
+		E195DA07BD54DDE970F27E56 /* Queue */ = {
+			isa = PBXGroup;
+			children = (
+				B18D78DD28112179ED6A17EA /* QueueDashboardView.swift */,
+				BCE344691F76FD3CE82E7FCF /* JobRowView.swift */,
+				33550E6E2F6D8F14E9A9C282 /* JobSetupView.swift */,
+				37404910B7FC7310289216C7 /* ScheduleSettingsView.swift */,
+			);
+			path = Queue;
 			sourceTree = "<group>";
 		};
 		F974D10D2BE0484500EFACBA = {
@@ -151,6 +195,7 @@
 				A1B2C3D4E5F6A7B8C9D0E1F3 /* VideoHelper.swift */,
 				26B0954A2C091C770097324A /* ThumbnailView.swift */,
 				26B095232C091B810097324A /* Processing */,
+				C0A7E6000010000000000005 /* Export */,
 				26B095212C091B740097324A /* Settings */,
 				AAC7DC5DCD23638D271D3093 /* Models */,
 				992CB303C65294FA4C0E9608 /* Scheduler */,
@@ -161,6 +206,14 @@
 			path = ObjectCaptureReconstruction;
 			sourceTree = "<group>";
 		};
+		C0A7E6000010000000000005 /* Export */ = {
+			isa = PBXGroup;
+			children = (
+				C0A7E6000010000000000004 /* OBJToGLTFConverter.swift */,
+			);
+			path = Export;
+			sourceTree = "<group>";
+		};
 		FE08FBE5E15C9B39D4421FC8 /* LICENSE */ = {
 			isa = PBXGroup;
 			children = (
@@ -168,44 +221,6 @@
 			);
 			name = LICENSE;
 			path = .;
-			sourceTree = "<group>";
-		};
-		AAC7DC5DCD23638D271D3093 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				5A00FFF0EB8B4E921061918F /* */,
-				AFC5AB62125CB98EAA9DF3F6 /* */,
-				958B6CDE5F744C8A9E27719D /* */,
-				E3A4F851B39B9C4EA08E7C13 /* */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		992CB303C65294FA4C0E9608 /* Scheduler */ = {
-			isa = PBXGroup;
-			children = (
-				A5722048B055E10C8C4635BA /* */,
-			);
-			path = Scheduler;
-			sourceTree = "<group>";
-		};
-		195BAF6352F89DD77AFC2745 /* Store */ = {
-			isa = PBXGroup;
-			children = (
-				B0C4F782DCEACB71739E8182 /* */,
-			);
-			path = Store;
-			sourceTree = "<group>";
-		};
-		E195DA07BD54DDE970F27E56 /* Queue */ = {
-			isa = PBXGroup;
-			children = (
-				B18D78DD28112179ED6A17EA /* */,
-				BCE344691F76FD3CE82E7FCF /* */,
-				33550E6E2F6D8F14E9A9C282 /* */,
-				37404910B7FC7310289216C7 /* */,
-			);
-			path = Queue;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -294,6 +309,8 @@
 				665189C5915C218406A40D61 /* JobRowView.swift in Sources */,
 				DC9509AE8DE723BBD01EC86D /* JobSetupView.swift in Sources */,
 				5B7275D8B81A2AA37B5D76A1 /* ScheduleSettingsView.swift in Sources */,
+				C0A7E6000010000000000001 /* ModelExportFormat.swift in Sources */,
+				C0A7E6000010000000000003 /* OBJToGLTFConverter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ObjectCaptureReconstruction/Export/OBJToGLTFConverter.swift
+++ b/ObjectCaptureReconstruction/Export/OBJToGLTFConverter.swift
@@ -1,0 +1,636 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Small OBJ/MTL to glTF 2.0 exporter used for Object Capture glTF and GLB output.
+*/
+
+import Foundation
+import simd
+
+enum OBJToGLTFConverter {
+    enum ExportError: LocalizedError {
+        case missingOBJFile(URL)
+        case invalidOBJ(String)
+        case unsupportedFormat(ModelExportFormat)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingOBJFile(let url):
+                return "No OBJ file was found in \(url.lastPathComponent)."
+            case .invalidOBJ(let message):
+                return "The OBJ output could not be converted: \(message)"
+            case .unsupportedFormat(let format):
+                return "\(format.displayName) is not supported by this exporter."
+            }
+        }
+    }
+
+    static func convertOBJFolder(
+        at sourceDirectory: URL,
+        to destinationURL: URL,
+        format: ModelExportFormat
+    ) throws {
+        let objURL = try findOBJFile(in: sourceDirectory)
+        let parsed = try OBJParser.parse(objURL: objURL)
+        var document = try GLTFDocument(parsedOBJ: parsed, sourceDirectory: sourceDirectory)
+
+        switch format {
+        case .gltf:
+            try document.writeGLTF(to: destinationURL)
+        case .glb:
+            try document.writeGLB(to: destinationURL)
+        case .usdz:
+            throw ExportError.unsupportedFormat(format)
+        }
+    }
+
+    private static func findOBJFile(in directory: URL) throws -> URL {
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        if let obj = contents.first(where: { $0.pathExtension.lowercased() == "obj" }) {
+            return obj
+        }
+        throw ExportError.missingOBJFile(directory)
+    }
+}
+
+private struct ParsedOBJ {
+    var positions: [SIMD3<Float>]
+    var normals: [SIMD3<Float>]
+    var texcoords: [SIMD2<Float>]
+    var primitives: [OBJPrimitive]
+    var materialLibraries: [String]
+}
+
+private struct OBJPrimitive {
+    var materialName: String?
+    var vertices: [OBJVertex]
+    var indices: [UInt32]
+    var vertexLookup: [OBJVertex: UInt32] = [:]
+}
+
+private struct OBJVertex: Hashable {
+    var position: Int
+    var texcoord: Int?
+    var normal: Int?
+}
+
+private enum OBJParser {
+    static func parse(objURL: URL) throws -> ParsedOBJ {
+        let text = try String(contentsOf: objURL, encoding: .utf8)
+        var positions: [SIMD3<Float>] = []
+        var normals: [SIMD3<Float>] = []
+        var texcoords: [SIMD2<Float>] = []
+        var primitives: [OBJPrimitive] = []
+        var materialLibraries: [String] = []
+        var activeMaterial: String?
+        var verticesByKey: [PrimitiveKey: UInt32] = [:]
+
+        func ensurePrimitive() {
+            let key = PrimitiveKey(materialName: activeMaterial)
+            if verticesByKey[key] == nil {
+                verticesByKey[key] = UInt32(primitives.count)
+                primitives.append(OBJPrimitive(materialName: activeMaterial, vertices: [], indices: []))
+            }
+        }
+
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+
+            let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+            guard let keyword = parts.first else { continue }
+
+            switch keyword {
+            case "v":
+                if let vector = parseVector3(parts.dropFirst()) {
+                    positions.append(vector)
+                }
+            case "vn":
+                if let vector = parseVector3(parts.dropFirst()) {
+                    normals.append(vector)
+                }
+            case "vt":
+                if let uv = parseVector2(parts.dropFirst()) {
+                    texcoords.append(uv)
+                }
+            case "mtllib":
+                let library = parts.dropFirst().joined(separator: " ")
+                if !library.isEmpty {
+                    materialLibraries.append(library)
+                }
+            case "usemtl":
+                activeMaterial = parts.dropFirst().joined(separator: " ")
+                if activeMaterial?.isEmpty == true {
+                    activeMaterial = nil
+                }
+                ensurePrimitive()
+            case "f":
+                ensurePrimitive()
+                let key = PrimitiveKey(materialName: activeMaterial)
+                guard let primitiveIndex = verticesByKey[key].map(Int.init) else { continue }
+                let faceVertices = try parts.dropFirst().map {
+                    try parseFaceVertex(
+                        String($0),
+                        positionCount: positions.count,
+                        texcoordCount: texcoords.count,
+                        normalCount: normals.count
+                    )
+                }
+                guard faceVertices.count >= 3 else { continue }
+
+                for i in 1..<(faceVertices.count - 1) {
+                    for vertex in [faceVertices[0], faceVertices[i], faceVertices[i + 1]] {
+                        let index = append(vertex: vertex, to: &primitives[primitiveIndex])
+                        primitives[primitiveIndex].indices.append(index)
+                    }
+                }
+            default:
+                continue
+            }
+        }
+
+        primitives.removeAll { $0.indices.isEmpty }
+        guard !positions.isEmpty, !primitives.isEmpty else {
+            throw OBJToGLTFConverter.ExportError.invalidOBJ("No mesh faces were found.")
+        }
+
+        return ParsedOBJ(
+            positions: positions,
+            normals: normals,
+            texcoords: texcoords,
+            primitives: primitives,
+            materialLibraries: materialLibraries
+        )
+    }
+
+    private static func append(vertex: OBJVertex, to primitive: inout OBJPrimitive) -> UInt32 {
+        if let existing = primitive.vertexLookup[vertex] {
+            return UInt32(existing)
+        }
+        let index = UInt32(primitive.vertices.count)
+        primitive.vertices.append(vertex)
+        primitive.vertexLookup[vertex] = index
+        return index
+    }
+
+    private static func parseVector3(_ values: ArraySlice<String>) -> SIMD3<Float>? {
+        let floats = values.prefix(3).compactMap(Float.init)
+        guard floats.count == 3 else { return nil }
+        return SIMD3(floats[0], floats[1], floats[2])
+    }
+
+    private static func parseVector2(_ values: ArraySlice<String>) -> SIMD2<Float>? {
+        let floats = values.prefix(2).compactMap(Float.init)
+        guard floats.count == 2 else { return nil }
+        return SIMD2(floats[0], floats[1])
+    }
+
+    private static func parseFaceVertex(
+        _ value: String,
+        positionCount: Int,
+        texcoordCount: Int,
+        normalCount: Int
+    ) throws -> OBJVertex {
+        let fields = value.split(separator: "/", omittingEmptySubsequences: false)
+        guard let position = resolveIndex(fields[safe: 0], count: positionCount) else {
+            throw OBJToGLTFConverter.ExportError.invalidOBJ("A face references a missing position.")
+        }
+        return OBJVertex(
+            position: position,
+            texcoord: resolveIndex(fields[safe: 1], count: texcoordCount),
+            normal: resolveIndex(fields[safe: 2], count: normalCount)
+        )
+    }
+
+    private static func resolveIndex(_ raw: Substring?, count: Int) -> Int? {
+        guard let raw, !raw.isEmpty, let value = Int(raw) else { return nil }
+        let index = value > 0 ? value - 1 : count + value
+        return (0..<count).contains(index) ? index : nil
+    }
+
+    private struct PrimitiveKey: Hashable {
+        var materialName: String?
+    }
+}
+
+private struct GLTFDocument {
+    private var parsedOBJ: ParsedOBJ
+    private var sourceDirectory: URL
+    private var materials: [String: MTLMaterial]
+    private var buffer = Data()
+    private var bufferViews: [[String: Any]] = []
+    private var accessors: [[String: Any]] = []
+    private var images: [[String: Any]] = []
+    private var textures: [[String: Any]] = []
+    private var gltfMaterials: [[String: Any]] = []
+    private var imageBufferViewIndices: [URL: Int] = [:]
+    private var copiedImageNames: Set<String> = []
+
+    init(parsedOBJ: ParsedOBJ, sourceDirectory: URL) throws {
+        self.parsedOBJ = parsedOBJ
+        self.sourceDirectory = sourceDirectory
+        self.materials = try MTLParser.parse(libraries: parsedOBJ.materialLibraries, sourceDirectory: sourceDirectory)
+    }
+
+    mutating func writeGLTF(to url: URL) throws {
+        let json = try buildJSON(destinationURL: url, embedImages: false)
+        let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+        try buffer.write(to: url.deletingPathExtension().appendingPathExtension("bin"), options: .atomic)
+    }
+
+    mutating func writeGLB(to url: URL) throws {
+        let json = try buildJSON(destinationURL: url, embedImages: true)
+        var jsonData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+        pad(&jsonData, byte: 0x20)
+
+        var binaryChunk = buffer
+        pad(&binaryChunk, byte: 0x00)
+
+        var glb = Data()
+        glb.appendUInt32(0x46546C67)
+        glb.appendUInt32(2)
+        glb.appendUInt32(UInt32(12 + 8 + jsonData.count + 8 + binaryChunk.count))
+        glb.appendUInt32(UInt32(jsonData.count))
+        glb.appendUInt32(0x4E4F534A)
+        glb.append(jsonData)
+        glb.appendUInt32(UInt32(binaryChunk.count))
+        glb.appendUInt32(0x004E4942)
+        glb.append(binaryChunk)
+        try glb.write(to: url, options: .atomic)
+    }
+
+    private mutating func buildJSON(destinationURL: URL, embedImages: Bool) throws -> [String: Any] {
+        buffer = Data()
+        bufferViews = []
+        accessors = []
+        images = []
+        textures = []
+        gltfMaterials = []
+        imageBufferViewIndices = [:]
+        copiedImageNames = []
+
+        let materialIndices = try buildMaterials(destinationURL: destinationURL, embedImages: embedImages)
+        let meshPrimitives = parsedOBJ.primitives.map { primitive -> [String: Any] in
+            let positionAccessor = addAccessor(
+                data: floatData(primitive.vertices.flatMap { parsedOBJ.positions[$0.position].array }),
+                componentType: 5126,
+                type: "VEC3",
+                count: primitive.vertices.count,
+                target: 34962,
+                min: bounds(for: primitive.vertices.map { parsedOBJ.positions[$0.position] }).min,
+                max: bounds(for: primitive.vertices.map { parsedOBJ.positions[$0.position] }).max
+            )
+
+            var attributes: [String: Any] = ["POSITION": positionAccessor]
+
+            if primitive.vertices.allSatisfy({ $0.normal != nil }) {
+                attributes["NORMAL"] = addAccessor(
+                    data: floatData(primitive.vertices.flatMap { parsedOBJ.normals[$0.normal!].array }),
+                    componentType: 5126,
+                    type: "VEC3",
+                    count: primitive.vertices.count,
+                    target: 34962
+                )
+            }
+
+            if primitive.vertices.allSatisfy({ $0.texcoord != nil }) {
+                attributes["TEXCOORD_0"] = addAccessor(
+                    data: floatData(primitive.vertices.flatMap {
+                        let uv = parsedOBJ.texcoords[$0.texcoord!]
+                        return [uv.x, 1 - uv.y]
+                    }),
+                    componentType: 5126,
+                    type: "VEC2",
+                    count: primitive.vertices.count,
+                    target: 34962
+                )
+            }
+
+            let indexAccessor = addAccessor(
+                data: indexData(primitive.indices),
+                componentType: 5125,
+                type: "SCALAR",
+                count: primitive.indices.count,
+                target: 34963
+            )
+
+            var result: [String: Any] = [
+                "attributes": attributes,
+                "indices": indexAccessor,
+                "mode": 4
+            ]
+
+            if let materialName = primitive.materialName,
+               let materialIndex = materialIndices[materialName] {
+                result["material"] = materialIndex
+            }
+
+            return result
+        }
+
+        var json: [String: Any] = [
+            "asset": [
+                "version": "2.0",
+                "generator": "Reality Pulse OBJToGLTFConverter"
+            ],
+            "scene": 0,
+            "scenes": [["nodes": [0]]],
+            "nodes": [["mesh": 0]],
+            "meshes": [["primitives": meshPrimitives]],
+            "buffers": [[
+                "byteLength": buffer.count,
+                "uri": destinationURL.deletingPathExtension().appendingPathExtension("bin").lastPathComponent
+            ]],
+            "bufferViews": bufferViews,
+            "accessors": accessors
+        ]
+
+        if embedImages {
+            json["buffers"] = [["byteLength": buffer.count]]
+        }
+        if !images.isEmpty { json["images"] = images }
+        if !textures.isEmpty { json["textures"] = textures }
+        if !gltfMaterials.isEmpty { json["materials"] = gltfMaterials }
+        return json
+    }
+
+    private mutating func buildMaterials(destinationURL: URL, embedImages: Bool) throws -> [String: Int] {
+        var indices: [String: Int] = [:]
+        for primitive in parsedOBJ.primitives {
+            guard let name = primitive.materialName, indices[name] == nil else { continue }
+            let material = materials[name] ?? MTLMaterial(name: name)
+            var pbr: [String: Any] = ["baseColorFactor": material.baseColorFactor]
+
+            if let textureURL = material.diffuseTextureURL(sourceDirectory: sourceDirectory) {
+                let imageIndex = try addImage(textureURL, destinationURL: destinationURL, embedImages: embedImages)
+                let textureIndex = textures.count
+                textures.append(["source": imageIndex])
+                pbr["baseColorTexture"] = ["index": textureIndex]
+            }
+
+            var gltfMaterial: [String: Any] = [
+                "name": name,
+                "pbrMetallicRoughness": pbr
+            ]
+
+            if material.alpha < 1 {
+                gltfMaterial["alphaMode"] = "BLEND"
+            }
+
+            indices[name] = gltfMaterials.count
+            gltfMaterials.append(gltfMaterial)
+        }
+        return indices
+    }
+
+    private mutating func addImage(_ sourceURL: URL, destinationURL: URL, embedImages: Bool) throws -> Int {
+        if embedImages {
+            if let existing = imageBufferViewIndices[sourceURL] {
+                return existing
+            }
+            let data = try Data(contentsOf: sourceURL)
+            let bufferView = addBufferView(data: data, target: nil)
+            let index = images.count
+            images.append([
+                "bufferView": bufferView,
+                "mimeType": mimeType(for: sourceURL)
+            ])
+            imageBufferViewIndices[sourceURL] = index
+            return index
+        }
+
+        let destinationName = uniqueImageName(sourceURL.lastPathComponent)
+        let outputURL = destinationURL.deletingLastPathComponent().appendingPathComponent(destinationName)
+        if sourceURL.standardizedFileURL != outputURL.standardizedFileURL {
+            if FileManager.default.fileExists(atPath: outputURL.path()) {
+                try FileManager.default.removeItem(at: outputURL)
+            }
+            try FileManager.default.copyItem(at: sourceURL, to: outputURL)
+        }
+        let index = images.count
+        images.append(["uri": destinationName])
+        return index
+    }
+
+    private mutating func addAccessor(
+        data: Data,
+        componentType: Int,
+        type: String,
+        count: Int,
+        target: Int?,
+        min: [Float]? = nil,
+        max: [Float]? = nil
+    ) -> Int {
+        let bufferView = addBufferView(data: data, target: target)
+        var accessor: [String: Any] = [
+            "bufferView": bufferView,
+            "componentType": componentType,
+            "count": count,
+            "type": type
+        ]
+        if let min { accessor["min"] = min }
+        if let max { accessor["max"] = max }
+        accessors.append(accessor)
+        return accessors.count - 1
+    }
+
+    private mutating func addBufferView(data: Data, target: Int?) -> Int {
+        alignBuffer()
+        let offset = buffer.count
+        buffer.append(data)
+        pad(&buffer, byte: 0x00)
+
+        var bufferView: [String: Any] = [
+            "buffer": 0,
+            "byteOffset": offset,
+            "byteLength": data.count
+        ]
+        if let target { bufferView["target"] = target }
+        bufferViews.append(bufferView)
+        return bufferViews.count - 1
+    }
+
+    private mutating func alignBuffer() {
+        pad(&buffer, byte: 0x00)
+    }
+
+    private mutating func uniqueImageName(_ name: String) -> String {
+        if !copiedImageNames.contains(name) {
+            copiedImageNames.insert(name)
+            return name
+        }
+
+        let url = URL(fileURLWithPath: name)
+        let base = url.deletingPathExtension().lastPathComponent
+        let ext = url.pathExtension
+        var candidate = name
+        var suffix = 2
+        while copiedImageNames.contains(candidate) {
+            candidate = ext.isEmpty ? "\(base)-\(suffix)" : "\(base)-\(suffix).\(ext)"
+            suffix += 1
+        }
+        copiedImageNames.insert(candidate)
+        return candidate
+    }
+
+    private func floatData(_ values: [Float]) -> Data {
+        var data = Data()
+        values.forEach { data.appendFloat32($0) }
+        return data
+    }
+
+    private func indexData(_ values: [UInt32]) -> Data {
+        var data = Data()
+        values.forEach { data.appendUInt32($0) }
+        return data
+    }
+
+    private func bounds(for positions: [SIMD3<Float>]) -> (min: [Float], max: [Float]) {
+        var minVector = positions[0]
+        var maxVector = positions[0]
+        for position in positions.dropFirst() {
+            minVector = simd_min(minVector, position)
+            maxVector = simd_max(maxVector, position)
+        }
+        return (minVector.array, maxVector.array)
+    }
+
+    private func mimeType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "jpg", "jpeg": return "image/jpeg"
+        case "webp": return "image/webp"
+        default: return "image/png"
+        }
+    }
+}
+
+private struct MTLMaterial {
+    var name: String
+    var diffuseColor = SIMD3<Float>(1, 1, 1)
+    var alpha: Float = 1
+    var diffuseTexture: String?
+
+    var baseColorFactor: [Float] {
+        [diffuseColor.x, diffuseColor.y, diffuseColor.z, alpha]
+    }
+
+    func diffuseTextureURL(sourceDirectory: URL) -> URL? {
+        guard let diffuseTexture else { return nil }
+        let url = sourceDirectory.appendingPathComponent(diffuseTexture)
+        return FileManager.default.fileExists(atPath: url.path()) ? url : nil
+    }
+}
+
+private enum MTLParser {
+    static func parse(libraries: [String], sourceDirectory: URL) throws -> [String: MTLMaterial] {
+        var materials: [String: MTLMaterial] = [:]
+
+        for library in libraries {
+            let url = sourceDirectory.appendingPathComponent(library)
+            guard FileManager.default.fileExists(atPath: url.path()) else { continue }
+            let text = try String(contentsOf: url, encoding: .utf8)
+            var current: MTLMaterial?
+
+            func saveCurrent() {
+                if let current {
+                    materials[current.name] = current
+                }
+            }
+
+            for rawLine in text.components(separatedBy: .newlines) {
+                let line = rawLine.trimmingCharacters(in: .whitespaces)
+                if line.isEmpty || line.hasPrefix("#") { continue }
+
+                let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+                guard let keyword = parts.first else { continue }
+
+                switch keyword {
+                case "newmtl":
+                    saveCurrent()
+                    current = MTLMaterial(name: parts.dropFirst().joined(separator: " "))
+                case "Kd":
+                    let floats = parts.dropFirst().prefix(3).compactMap(Float.init)
+                    if floats.count == 3 {
+                        current?.diffuseColor = SIMD3(floats[0], floats[1], floats[2])
+                    }
+                case "d":
+                    if let alpha = parts.dropFirst().first.flatMap(Float.init) {
+                        current?.alpha = alpha
+                    }
+                case "Tr":
+                    if let transparency = parts.dropFirst().first.flatMap(Float.init) {
+                        current?.alpha = 1 - transparency
+                    }
+                case "map_Kd":
+                    current?.diffuseTexture = parseTexturePath(Array(parts.dropFirst()))
+                default:
+                    continue
+                }
+            }
+
+            saveCurrent()
+        }
+
+        return materials
+    }
+
+    private static func parseTexturePath(_ fields: [String]) -> String? {
+        guard !fields.isEmpty else { return nil }
+        var index = 0
+        while index < fields.count {
+            let field = fields[index]
+            if field.hasPrefix("-") {
+                index += optionValueCount(for: field) + 1
+            } else {
+                break
+            }
+        }
+        guard index < fields.count else { return nil }
+        return fields[index...].joined(separator: " ")
+    }
+
+    private static func optionValueCount(for option: String) -> Int {
+        switch option {
+        case "-blendu", "-blendv", "-cc", "-clamp", "-texres":
+            return 1
+        case "-mm", "-o", "-s", "-t":
+            return 3
+        default:
+            return 0
+        }
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}
+
+private extension SIMD3 where Scalar == Float {
+    var array: [Float] { [x, y, z] }
+}
+
+private func pad(_ data: inout Data, byte: UInt8) {
+    let padding = (4 - (data.count % 4)) % 4
+    if padding > 0 {
+        data.append(contentsOf: Array(repeating: byte, count: padding))
+    }
+}
+
+private extension Data {
+    mutating func appendUInt32(_ value: UInt32) {
+        var littleEndian = value.littleEndian
+        append(Data(bytes: &littleEndian, count: MemoryLayout<UInt32>.size))
+    }
+
+    mutating func appendFloat32(_ value: Float) {
+        var bitPattern = value.bitPattern.littleEndian
+        append(Data(bytes: &bitPattern, count: MemoryLayout<UInt32>.size))
+    }
+}

--- a/ObjectCaptureReconstruction/Models/JobDraft.swift
+++ b/ObjectCaptureReconstruction/Models/JobDraft.swift
@@ -40,6 +40,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
     var sessionConfiguration: PhotogrammetrySession.Configuration = PhotogrammetrySession.Configuration()
     var detailLevelOptionUnderQualityMenu: PhotogrammetrySession.Request.Detail = .medium
     var detailLevelOptionsUnderAdvancedMenu = CodableDetailLevelOptions()
+    var exportFormats: Set<ModelExportFormat> = [.usdz]
 
     // MARK: - Error surface (used by ImageFolderView, ModelFolderView, etc.)
 
@@ -61,6 +62,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
         sessionConfiguration = job.sessionConfiguration.toSessionConfiguration()
         detailLevelOptionUnderQualityMenu = job.primaryDetailLevel.toFrameworkType
         detailLevelOptionsUnderAdvancedMenu = job.additionalDetailLevels
+        exportFormats = job.exportFormats
     }
 
     // MARK: - Conversion
@@ -73,12 +75,14 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
         }
 
         var job = ReconstructionJob(
+            id: existingId ?? UUID(),
             imageFolder: imageFolder,
             modelFolder: modelFolder,
             modelName: modelName,
             sessionConfiguration: CodableSessionConfiguration(from: sessionConfiguration),
             primaryDetailLevel: CodableDetailLevel(from: detailLevelOptionUnderQualityMenu),
-            additionalDetailLevels: detailLevelOptionsUnderAdvancedMenu
+            additionalDetailLevels: detailLevelOptionsUnderAdvancedMenu,
+            exportFormats: exportFormats
         )
         job.boundingBoxAvailable = boundingBoxAvailable
         return job

--- a/ObjectCaptureReconstruction/Models/ModelExportFormat.swift
+++ b/ObjectCaptureReconstruction/Models/ModelExportFormat.swift
@@ -1,0 +1,33 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Supported model export formats for reconstruction jobs.
+*/
+
+import Foundation
+
+enum ModelExportFormat: String, Codable, CaseIterable, Hashable, Identifiable {
+    case usdz
+    case gltf
+    case glb
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .usdz: return "USDZ"
+        case .gltf: return "glTF"
+        case .glb: return "GLB"
+        }
+    }
+
+    var fileExtension: String {
+        switch self {
+        case .usdz: return "usdz"
+        case .gltf: return "gltf"
+        case .glb: return "glb"
+        }
+    }
+}
+

--- a/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
+++ b/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
@@ -19,6 +19,7 @@ struct ReconstructionJob: Identifiable, Codable {
     var sessionConfiguration: CodableSessionConfiguration
     var primaryDetailLevel: CodableDetailLevel
     var additionalDetailLevels: CodableDetailLevelOptions
+    var exportFormats: Set<ModelExportFormat>
 
     var status: JobStatus = .pending
     var progress: Double = 0
@@ -31,20 +32,23 @@ struct ReconstructionJob: Identifiable, Codable {
     var modelFolderBookmark: Data?
 
     init(
+        id: UUID = UUID(),
         imageFolder: URL,
         modelFolder: URL,
         modelName: String,
         sessionConfiguration: CodableSessionConfiguration = CodableSessionConfiguration(),
         primaryDetailLevel: CodableDetailLevel = .medium,
-        additionalDetailLevels: CodableDetailLevelOptions = CodableDetailLevelOptions()
+        additionalDetailLevels: CodableDetailLevelOptions = CodableDetailLevelOptions(),
+        exportFormats: Set<ModelExportFormat> = [.usdz]
     ) {
-        self.id = UUID()
+        self.id = id
         self.imageFolder = imageFolder
         self.modelFolder = modelFolder
         self.modelName = modelName
         self.sessionConfiguration = sessionConfiguration
         self.primaryDetailLevel = primaryDetailLevel
         self.additionalDetailLevels = additionalDetailLevels
+        self.exportFormats = exportFormats.isEmpty ? [.usdz] : exportFormats
         self.createdAt = Date()
 
         self.imageFolderBookmark = try? imageFolder.bookmarkData(
@@ -76,9 +80,102 @@ struct ReconstructionJob: Identifiable, Codable {
 
     /// Build `PhotogrammetrySession.Request` entries for all requested detail levels.
     func createReconstructionRequests() -> [PhotogrammetrySession.Request] {
-        allRequestedDetailLevels.map { level in
-            let url = modelFolder.appending(path: "\(modelName)-\(level.rawValue).usdz")
-            return .modelFile(url: url, detail: level.toFrameworkType)
+        createModelExportRequests().map(\.photogrammetryRequest)
+    }
+
+    /// Build Object Capture requests plus final export targets for each detail level.
+    func createModelExportRequests() -> [ModelExportRequest] {
+        let formats = exportFormats.isEmpty ? Set([.usdz]) : exportFormats
+        return allRequestedDetailLevels
+            .sorted { $0.rawValue < $1.rawValue }
+            .flatMap { level -> [ModelExportRequest] in
+                var requests: [ModelExportRequest] = []
+
+                if formats.contains(.usdz) {
+                    let url = modelFolder.appending(path: "\(modelName)-\(level.rawValue).usdz")
+                    requests.append(ModelExportRequest(
+                        detailLevel: level,
+                        photogrammetryRequest: .modelFile(url: url, detail: level.toFrameworkType),
+                        targets: [ModelExportTarget(format: .usdz, url: url)],
+                        intermediateDirectory: nil
+                    ))
+                }
+
+                let gltfFormats = formats.intersection([.gltf, .glb])
+                if !gltfFormats.isEmpty {
+                    let sourceDirectory = modelFolder.appending(
+                        path: ".\(modelName)-\(level.rawValue)-gltf-source-\(id.uuidString)"
+                    )
+                    let targets = gltfFormats
+                        .sorted { $0.rawValue < $1.rawValue }
+                        .map { format in
+                            ModelExportTarget(
+                                format: format,
+                                url: modelFolder.appending(path: "\(modelName)-\(level.rawValue).\(format.fileExtension)")
+                            )
+                        }
+                    requests.append(ModelExportRequest(
+                        detailLevel: level,
+                        photogrammetryRequest: .modelFile(url: sourceDirectory, detail: level.toFrameworkType),
+                        targets: targets,
+                        intermediateDirectory: sourceDirectory
+                    ))
+                }
+
+                return requests
+            }
+    }
+
+    func outputFilenames() -> [String] {
+        let formats = exportFormats.isEmpty ? Set([.usdz]) : exportFormats
+        return allRequestedDetailLevels
+            .sorted { $0.rawValue < $1.rawValue }
+            .flatMap { level in
+                formats
+                    .sorted { $0.rawValue < $1.rawValue }
+                    .map { "\(modelName)-\(level.rawValue).\($0.fileExtension)" }
+            }
+    }
+
+    // MARK: - Codable
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case imageFolder
+        case modelFolder
+        case modelName
+        case sessionConfiguration
+        case primaryDetailLevel
+        case additionalDetailLevels
+        case exportFormats
+        case status
+        case progress
+        case errorMessage
+        case boundingBoxAvailable
+        case createdAt
+        case imageFolderBookmark
+        case modelFolderBookmark
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        imageFolder = try container.decode(URL.self, forKey: .imageFolder)
+        modelFolder = try container.decode(URL.self, forKey: .modelFolder)
+        modelName = try container.decode(String.self, forKey: .modelName)
+        sessionConfiguration = try container.decode(CodableSessionConfiguration.self, forKey: .sessionConfiguration)
+        primaryDetailLevel = try container.decode(CodableDetailLevel.self, forKey: .primaryDetailLevel)
+        additionalDetailLevels = try container.decode(CodableDetailLevelOptions.self, forKey: .additionalDetailLevels)
+        exportFormats = try container.decodeIfPresent(Set<ModelExportFormat>.self, forKey: .exportFormats) ?? [.usdz]
+        status = try container.decodeIfPresent(JobStatus.self, forKey: .status) ?? .pending
+        progress = try container.decodeIfPresent(Double.self, forKey: .progress) ?? 0
+        errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        boundingBoxAvailable = try container.decodeIfPresent(Bool.self, forKey: .boundingBoxAvailable) ?? false
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        imageFolderBookmark = try container.decodeIfPresent(Data.self, forKey: .imageFolderBookmark)
+        modelFolderBookmark = try container.decodeIfPresent(Data.self, forKey: .modelFolderBookmark)
+        if exportFormats.isEmpty {
+            exportFormats = [.usdz]
         }
     }
 
@@ -156,4 +253,23 @@ struct CodableDetailLevelOptions: Codable, Equatable {
     var medium: Bool = false
     var full: Bool = false
     var raw: Bool = false
+}
+
+struct ModelExportRequest {
+    var detailLevel: CodableDetailLevel
+    var photogrammetryRequest: PhotogrammetrySession.Request
+    var targets: [ModelExportTarget]
+    var intermediateDirectory: URL?
+
+    var outputURL: URL? {
+        if case .modelFile(let url, _, _) = photogrammetryRequest {
+            return url
+        }
+        return nil
+    }
+}
+
+struct ModelExportTarget {
+    var format: ModelExportFormat
+    var url: URL
 }

--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -231,7 +231,8 @@ class JobScheduler {
         }
 
         let config = jobs[index].sessionConfiguration.toSessionConfiguration()
-        let requests = jobs[index].createReconstructionRequests()
+        let exportRequests = jobs[index].createModelExportRequests()
+        let requests = exportRequests.map(\.photogrammetryRequest)
 
         guard !requests.isEmpty else {
             jobs[index].status = .failed
@@ -242,6 +243,15 @@ class JobScheduler {
         }
 
         do {
+            for exportRequest in exportRequests {
+                if let intermediateDirectory = exportRequest.intermediateDirectory {
+                    try FileManager.default.createDirectory(
+                        at: intermediateDirectory,
+                        withIntermediateDirectories: true
+                    )
+                }
+            }
+
             let session = try await createSession(
                 imageFolder: jobs[index].imageFolder,
                 configuration: config
@@ -268,8 +278,9 @@ class JobScheduler {
                 case .requestProgressInfo(_, let info):
                     estimatedTimeRemaining = info.estimatedRemainingTime
 
-                case .requestComplete(_, _):
+                case .requestComplete(let request, _):
                     logger.log("Request completed for job \(jobId).")
+                    try await finishExport(for: request, in: exportRequests)
 
                 case .requestError(_, let error):
                     logger.warning("Request error for job \(jobId): \(error)")
@@ -327,6 +338,28 @@ class JobScheduler {
         logger.log("Scheduler paused between jobs.")
     }
 
+    private nonisolated func finishExport(
+        for request: PhotogrammetrySession.Request,
+        in exportRequests: [ModelExportRequest]
+    ) async throws {
+        guard let sourceURL = request.modelFileURL,
+              let exportRequest = exportRequests.first(where: { $0.outputURL == sourceURL }),
+              let intermediateDirectory = exportRequest.intermediateDirectory else {
+            return
+        }
+
+        for target in exportRequest.targets where target.format != .usdz {
+            try OBJToGLTFConverter.convertOBJFolder(
+                at: intermediateDirectory,
+                to: target.url,
+                format: target.format
+            )
+            logger.log("Exported \(target.format.displayName) model to \(target.url.lastPathComponent)")
+        }
+
+        try? FileManager.default.removeItem(at: intermediateDirectory)
+    }
+
     // MARK: - Session creation (nonisolated to avoid blocking main actor)
 
     private nonisolated func createSession(
@@ -371,5 +404,14 @@ class JobScheduler {
                 logger.warning("Failed to schedule notification: \(error)")
             }
         }
+    }
+}
+
+private extension PhotogrammetrySession.Request {
+    var modelFileURL: URL? {
+        if case .modelFile(let url, _, _) = self {
+            return url
+        }
+        return nil
     }
 }

--- a/ObjectCaptureReconstruction/Settings/ProcessButton/ProcessButton.swift
+++ b/ObjectCaptureReconstruction/Settings/ProcessButton/ProcessButton.swift
@@ -28,7 +28,7 @@ struct ProcessButton: View {
 
             Button(isEditing ? "Save Changes" : "Add to Queue") {
                 guard draft.validate() else { return }
-                guard let job = draft.toJob() else { return }
+                guard let job = draft.toJob(existingId: appDataModel.editingJob?.id) else { return }
                 logger.log("Adding job to queue: \(job.modelName)")
 
                 if isEditing, let editingJob = appDataModel.editingJob {

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ExportFormatView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ExportFormatView.swift
@@ -1,0 +1,34 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Choose the model file formats to export for a reconstruction job.
+*/
+
+import SwiftUI
+
+struct ExportFormatView: View {
+    @Environment(JobDraft.self) private var draft: JobDraft
+
+    var body: some View {
+        @Bindable var draft = draft
+
+        Section {
+            ForEach(ModelExportFormat.allCases) { format in
+                Toggle(format.displayName, isOn: Binding(
+                    get: { draft.exportFormats.contains(format) },
+                    set: { isSelected in
+                        if isSelected {
+                            draft.exportFormats.insert(format)
+                        } else if draft.exportFormats.count > 1 {
+                            draft.exportFormats.remove(format)
+                        }
+                    }
+                ))
+            }
+        } header: {
+            Text("Export Formats")
+        }
+    }
+}
+

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/OutputPreviewView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/OutputPreviewView.swift
@@ -51,8 +51,13 @@ struct OutputPreviewView: View {
             if draft.detailLevelOptionsUnderAdvancedMenu.full { levels.insert(.full) }
             if draft.detailLevelOptionsUnderAdvancedMenu.raw { levels.insert(.raw) }
         }
+        let formats = draft.exportFormats.isEmpty ? Set([.usdz]) : draft.exportFormats
         return levels
             .sorted { $0.rawValue < $1.rawValue }
-            .map { "\(name)-\($0.rawValue).usdz" }
+            .flatMap { level in
+                formats
+                    .sorted { $0.rawValue < $1.rawValue }
+                    .map { "\(name)-\(level.rawValue).\($0.fileExtension)" }
+            }
     }
 }

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ReconstructionOptionsView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ReconstructionOptionsView.swift
@@ -16,6 +16,8 @@ struct ReconstructionOptionsView: View {
 
         MultiModelOutputView()
 
+        ExportFormatView()
+
         OutputPreviewView()
 
         Divider()


### PR DESCRIPTION
## Summary
- Add per-job export format selection for USDZ, glTF, and GLB
- Convert Object Capture OBJ output into glTF 2.0 / binary GLB exports
- Update output preview and job persistence to include export formats

## Testing
- `xcodebuild` build succeeded for the macOS app target
- Local fixture export test passed for a mesh with material and texture, covering `.gltf` and `.glb` output