### PR TITLE
✨ Add provenance watermarking option to exports

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app
 
+      - name: Test RealityMarkKit package
+        run: swift test --package-path RealityMarkKit
+
       - name: Build
         run: |
           xcodebuild -project RealityPulse.xcodeproj \

--- a/ObjectCaptureReconstruction/Export/USDZStamper.swift
+++ b/ObjectCaptureReconstruction/Export/USDZStamper.swift
@@ -35,9 +35,33 @@ enum USDZStamper {
         var fileSHA256: String
     }
 
+    /// A stamped copy written to a temporary location, not yet swapped in.
+    /// Lets the caller persist the provenance record between staging and
+    /// committing, so a marked file can never exist without its record.
+    struct StagedStamp {
+        var temporaryURL: URL
+        var stampedImages: [WatermarkRecord.TextureChannelInfo.Image]
+        /// SHA-256 of the staged bytes — identical to the destination file's
+        /// hash after `commit`.
+        var fileSHA256: String
+    }
+
     /// Stamp the base-color textures of a finished USDZ in place, atomically.
     /// Any failure throws before the original file is replaced.
     nonisolated static func stampTextures(usdzURL: URL, stamp: WatermarkStamp) throws -> StampResult {
+        let staged = try stage(usdzURL: usdzURL, stamp: stamp)
+        do {
+            try commit(staged, to: usdzURL)
+        } catch {
+            discard(staged)
+            throw error
+        }
+        return StampResult(stampedImages: staged.stampedImages, fileSHA256: staged.fileSHA256)
+    }
+
+    /// Produce a stamped copy in a temporary location; the original stays
+    /// untouched until `commit`.
+    nonisolated static func stage(usdzURL: URL, stamp: WatermarkStamp) throws -> StagedStamp {
         var archive = try UsdzArchive.read(url: usdzURL)
         let baseColorNames = baseColorTextureNames(usdzURL: usdzURL)
 
@@ -74,13 +98,22 @@ enum USDZStamper {
         let temporaryURL = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString + ".usdz")
         try archive.write(to: temporaryURL)
-        _ = try FileManager.default.replaceItemAt(usdzURL, withItemAt: temporaryURL)
 
-        logger.log("Stamped \(stampedImages.count) texture(s) in \(usdzURL.lastPathComponent, privacy: .public)")
-        return StampResult(
+        return StagedStamp(
+            temporaryURL: temporaryURL,
             stampedImages: stampedImages,
-            fileSHA256: try WatermarkingService.sha256Hex(of: usdzURL)
+            fileSHA256: try WatermarkingService.sha256Hex(of: temporaryURL)
         )
+    }
+
+    /// Atomically replace the destination with the staged copy.
+    nonisolated static func commit(_ staged: StagedStamp, to usdzURL: URL) throws {
+        _ = try FileManager.default.replaceItemAt(usdzURL, withItemAt: staged.temporaryURL)
+        logger.log("Stamped \(staged.stampedImages.count) texture(s) in \(usdzURL.lastPathComponent, privacy: .public)")
+    }
+
+    nonisolated static func discard(_ staged: StagedStamp) {
+        try? FileManager.default.removeItem(at: staged.temporaryURL)
     }
 
     /// Base-color texture filenames according to ModelIO's material graph.

--- a/ObjectCaptureReconstruction/Export/USDZStamper.swift
+++ b/ObjectCaptureReconstruction/Export/USDZStamper.swift
@@ -1,0 +1,132 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Texture-channel provenance stamping for finished USDZ files. The USDZ is a
+stored (uncompressed) zip: texture image entries are decoded, watermarked, and
+re-encoded in place while the `.usdc` geometry bytes are copied verbatim, so
+the primary deliverable's structure and materials are never touched.
+*/
+
+import Foundation
+import ModelFileIO
+import ModelIO
+import WatermarkCore
+import os
+
+private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
+                            category: "USDZStamper")
+
+enum USDZStamper {
+
+    enum StamperError: LocalizedError {
+        case noStampableTextures(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noStampableTextures(let name):
+                return "No stampable base-color textures found in \(name)."
+            }
+        }
+    }
+
+    struct StampResult {
+        var stampedImages: [WatermarkRecord.TextureChannelInfo.Image]
+        var fileSHA256: String
+    }
+
+    /// Stamp the base-color textures of a finished USDZ in place, atomically.
+    /// Any failure throws before the original file is replaced.
+    nonisolated static func stampTextures(usdzURL: URL, stamp: WatermarkStamp) throws -> StampResult {
+        var archive = try UsdzArchive.read(url: usdzURL)
+        let baseColorNames = baseColorTextureNames(usdzURL: usdzURL)
+
+        var stampedImages: [WatermarkRecord.TextureChannelInfo.Image] = []
+        for index in archive.entries.indices {
+            let entry = archive.entries[index]
+            guard let format = ImageCodec.imageFormat(of: entry.data),
+                  isBaseColorEntry(entry.name, knownNames: baseColorNames) else { continue }
+
+            let image = try ImageCodec.decode(entry.data)
+            let stamped = try TextureWatermarker.embed(
+                image: image,
+                key: stamp.key,
+                parameters: stamp.textureParameters
+            )
+            switch format {
+            case .png:
+                archive.entries[index].data = try ImageCodec.pngData(from: stamped)
+            case .jpeg:
+                archive.entries[index].data = try ImageCodec.jpegData(from: stamped, quality: 0.95)
+            }
+            stampedImages.append(WatermarkRecord.TextureChannelInfo.Image(
+                name: entry.name,
+                semantic: "baseColor",
+                width: stamped.width,
+                height: stamped.height
+            ))
+        }
+
+        guard !stampedImages.isEmpty else {
+            throw StamperError.noStampableTextures(usdzURL.lastPathComponent)
+        }
+
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString + ".usdz")
+        try archive.write(to: temporaryURL)
+        _ = try FileManager.default.replaceItemAt(usdzURL, withItemAt: temporaryURL)
+
+        logger.log("Stamped \(stampedImages.count) texture(s) in \(usdzURL.lastPathComponent, privacy: .public)")
+        return StampResult(
+            stampedImages: stampedImages,
+            fileSHA256: try WatermarkingService.sha256Hex(of: usdzURL)
+        )
+    }
+
+    /// Base-color texture filenames according to ModelIO's material graph.
+    /// Empty when ModelIO can't say (the name heuristic then decides alone).
+    private nonisolated static func baseColorTextureNames(usdzURL: URL) -> Set<String> {
+        let asset = MDLAsset(url: usdzURL)
+        var names = Set<String>()
+        for index in 0..<asset.count {
+            guard let object = asset.object(at: index) as? MDLObject else { continue }
+            collectBaseColorNames(from: object, into: &names)
+        }
+        return names
+    }
+
+    private nonisolated static func collectBaseColorNames(from object: MDLObject, into names: inout Set<String>) {
+        if let mesh = object as? MDLMesh {
+            for submesh in mesh.submeshes ?? [] {
+                guard let submesh = submesh as? MDLSubmesh,
+                      let material = submesh.material,
+                      let property = material.property(with: .baseColor),
+                      property.type == .texture else { continue }
+                if let name = property.textureSamplerValue?.texture?.name, !name.isEmpty {
+                    names.insert((name as NSString).lastPathComponent)
+                }
+                if let path = property.urlValue?.lastPathComponent {
+                    names.insert(path)
+                }
+            }
+        }
+        for child in object.children.objects {
+            collectBaseColorNames(from: child, into: &names)
+        }
+    }
+
+    /// Object Capture texture names: base color has no channel suffix, other
+    /// maps carry norm/rough/metal/ao/… markers.
+    private nonisolated static let nonBaseColorMarkers = [
+        "norm", "rough", "metal", "ao", "occl", "disp", "opacity", "emissive"
+    ]
+
+    private nonisolated static func isBaseColorEntry(_ entryName: String, knownNames: Set<String>) -> Bool {
+        let filename = (entryName as NSString).lastPathComponent
+        if !knownNames.isEmpty {
+            return knownNames.contains(filename)
+        }
+        let lowered = filename.lowercased()
+        return !nonBaseColorMarkers.contains { lowered.contains($0) }
+    }
+}

--- a/ObjectCaptureReconstruction/Export/USDZToGLTFConverter.swift
+++ b/ObjectCaptureReconstruction/Export/USDZToGLTFConverter.swift
@@ -10,6 +10,7 @@ import Foundation
 import ModelIO
 import ImageIO
 import UniformTypeIdentifiers
+import WatermarkCore
 import simd
 import os
 
@@ -45,11 +46,16 @@ enum USDZToGLTFConverterError: LocalizedError {
 enum USDZToGLTFConverter {
 
     /// Convert a `.usdz` file to the requested glTF container format.
+    /// When `watermark` is set, the vertex positions (all meshes as one point
+    /// set) and base-color textures are stamped with the per-copy key before
+    /// serialization; the returned outcome says which channels were embedded.
+    @discardableResult
     nonisolated static func convert(
         usdzURL: URL,
         format: ModelExportFormat,
-        outputURL: URL
-    ) throws {
+        outputURL: URL,
+        watermark: WatermarkStamp? = nil
+    ) throws -> WatermarkStampOutcome {
         let asset = MDLAsset(url: usdzURL)
         guard asset.count > 0 else {
             throw USDZToGLTFConverterError.failedToLoadAsset(usdzURL)
@@ -83,6 +89,9 @@ enum USDZToGLTFConverter {
             wrapT: GLTFConstants.wrapRepeat
         )]
 
+        // Pass 1: extract all vertex data so the geometry watermark can treat
+        // every mesh as one point set (global centroid and bins).
+        var preparedMeshes: [PreparedMesh] = []
         for (mesh, transform) in meshes {
             mesh.addNormals(withAttributeNamed: MDLVertexAttributeNormal, creaseThreshold: 0.5)
             if mesh.vertexAttributeData(forAttributeNamed: MDLVertexAttributeTextureCoordinate) != nil {
@@ -96,9 +105,44 @@ enum USDZToGLTFConverter {
             let positions = extractFloat3(from: mesh, attribute: MDLVertexAttributePosition, transform: transform)
             guard !positions.isEmpty else { continue }
 
-            let normals = extractFloat3(from: mesh, attribute: MDLVertexAttributeNormal, transform: transform, isDirection: true)
-            let tangents = extractFloat4(from: mesh, attribute: MDLVertexAttributeTangent)
-            let uvs = extractTexCoords(from: mesh, attribute: MDLVertexAttributeTextureCoordinate)
+            preparedMeshes.append(PreparedMesh(
+                mesh: mesh,
+                positions: positions,
+                normals: extractFloat3(from: mesh, attribute: MDLVertexAttributeNormal, transform: transform, isDirection: true),
+                tangents: extractFloat4(from: mesh, attribute: MDLVertexAttributeTangent),
+                uvs: extractTexCoords(from: mesh, attribute: MDLVertexAttributeTextureCoordinate)
+            ))
+        }
+
+        var geometryInfo: WatermarkRecord.GeometryChannelInfo?
+        if let watermark {
+            var allPositions = preparedMeshes.flatMap(\.positions)
+            let embedResult = GeometryWatermarker.embed(
+                positions: &allPositions,
+                key: watermark.key,
+                parameters: watermark.geometryParameters
+            )
+            if embedResult.isEmbedded {
+                var cursor = 0
+                for index in preparedMeshes.indices {
+                    let count = preparedMeshes[index].positions.count
+                    preparedMeshes[index].positions = Array(allPositions[cursor..<(cursor + count)])
+                    cursor += count
+                }
+                geometryInfo = WatermarkRecord.GeometryChannelInfo(
+                    parameters: watermark.geometryParameters,
+                    effectiveBinCount: embedResult.effectiveBinCount,
+                    embeddedBits: embedResult.embeddedBits
+                )
+            } else {
+                logger.log("Geometry watermark skipped for \(outputURL.lastPathComponent): too few vertices or degenerate shape.")
+            }
+        }
+
+        // Pass 2: serialize.
+        var stampedImages: [WatermarkRecord.TextureChannelInfo.Image] = []
+        for prepared in preparedMeshes {
+            let positions = prepared.positions
 
             let positionAccessor = builder.appendFloatBuffer(
                 positions.flatMap { [$0.x, $0.y, $0.z] },
@@ -106,24 +150,24 @@ enum USDZToGLTFConverter {
                 min: vectorMin(positions),
                 max: vectorMax(positions)
             )
-            let normalAccessor = normals.isEmpty ? nil : builder.appendFloatBuffer(
-                normals.flatMap { [$0.x, $0.y, $0.z] },
+            let normalAccessor = prepared.normals.isEmpty ? nil : builder.appendFloatBuffer(
+                prepared.normals.flatMap { [$0.x, $0.y, $0.z] },
                 componentsPerElement: 3
             )
             // The V flip applied to UVs reverses the bitangent direction, so negate
             // the stored handedness to keep normal maps oriented correctly.
-            let tangentAccessor = tangents.isEmpty ? nil : builder.appendFloatBuffer(
-                tangents.flatMap { [$0.x, $0.y, $0.z, -$0.w] },
+            let tangentAccessor = prepared.tangents.isEmpty ? nil : builder.appendFloatBuffer(
+                prepared.tangents.flatMap { [$0.x, $0.y, $0.z, -$0.w] },
                 componentsPerElement: 4
             )
-            let texCoordAccessor = uvs.isEmpty ? nil : builder.appendFloatBuffer(
-                uvs.flatMap { [$0.x, $0.y] },
+            let texCoordAccessor = prepared.uvs.isEmpty ? nil : builder.appendFloatBuffer(
+                prepared.uvs.flatMap { [$0.x, $0.y] },
                 componentsPerElement: 2
             )
 
             var primitives: [GLTFPrimitive] = []
 
-            for submesh in mesh.submeshes ?? [] {
+            for submesh in prepared.mesh.submeshes ?? [] {
                 guard let submesh = submesh as? MDLSubmesh else { continue }
 
                 let indexAccessor = try appendIndices(from: submesh, builder: builder)
@@ -137,7 +181,9 @@ enum USDZToGLTFConverter {
                     builder: builder,
                     outputDirectory: outputURL.deletingLastPathComponent(),
                     embedImages: format == .glb,
-                    defaultSamplerIndex: defaultSamplerIndex
+                    defaultSamplerIndex: defaultSamplerIndex,
+                    watermark: watermark,
+                    stampedImages: &stampedImages
                 )
 
                 var attributes: [String: Int] = [
@@ -182,6 +228,14 @@ enum USDZToGLTFConverter {
             samplers: samplers
         )
 
+        var textureInfo: WatermarkRecord.TextureChannelInfo?
+        if let watermark, !stampedImages.isEmpty {
+            textureInfo = WatermarkRecord.TextureChannelInfo(
+                parameters: watermark.textureParameters,
+                images: stampedImages
+            )
+        }
+
         switch format {
         case .glb:
             try GLTFWriter.writeGLB(document: document, binaryData: builder.data, to: outputURL)
@@ -193,6 +247,17 @@ enum USDZToGLTFConverter {
         }
 
         logger.log("Exported \(outputURL.lastPathComponent) from \(usdzURL.lastPathComponent)")
+        return WatermarkStampOutcome(geometry: geometryInfo, texture: textureInfo)
+    }
+
+    /// Vertex data extracted in pass 1, serialized in pass 2 (with the
+    /// geometry watermark applied to `positions` in between).
+    private struct PreparedMesh {
+        let mesh: MDLMesh
+        var positions: [SIMD3<Float>]
+        let normals: [SIMD3<Float>]
+        let tangents: [SIMD4<Float>]
+        let uvs: [SIMD2<Float>]
     }
 
     // MARK: - Vertex extraction
@@ -287,7 +352,9 @@ enum USDZToGLTFConverter {
         builder: GLTFBinaryBuilder,
         outputDirectory: URL,
         embedImages: Bool,
-        defaultSamplerIndex: Int
+        defaultSamplerIndex: Int,
+        watermark: WatermarkStamp? = nil,
+        stampedImages: inout [WatermarkRecord.TextureChannelInfo.Image]
     ) -> Int? {
         let cacheKey = material?.name ?? "default"
         if let existing = materialCache[cacheKey] {
@@ -319,7 +386,9 @@ enum USDZToGLTFConverter {
                 outputDirectory: outputDirectory,
                 embedImages: embedImages,
                 defaultSamplerIndex: defaultSamplerIndex,
-                repackAsMetallicRoughness: false
+                repackAsMetallicRoughness: false,
+                watermark: watermark,
+                stampedImages: &stampedImages
             ) {
                 pbr.baseColorTexture = GLTFTextureInfo(index: textureIndex)
             }
@@ -334,7 +403,8 @@ enum USDZToGLTFConverter {
                 outputDirectory: outputDirectory,
                 embedImages: embedImages,
                 defaultSamplerIndex: defaultSamplerIndex,
-                repackAsMetallicRoughness: true
+                repackAsMetallicRoughness: true,
+                stampedImages: &stampedImages
             ) {
                 pbr.metallicRoughnessTexture = GLTFTextureInfo(index: textureIndex)
             }
@@ -349,7 +419,8 @@ enum USDZToGLTFConverter {
                 outputDirectory: outputDirectory,
                 embedImages: embedImages,
                 defaultSamplerIndex: defaultSamplerIndex,
-                repackAsMetallicRoughness: false
+                repackAsMetallicRoughness: false,
+                stampedImages: &stampedImages
             ) {
                 normalTexture = GLTFNormalTextureInfo(index: textureIndex)
             }
@@ -364,7 +435,8 @@ enum USDZToGLTFConverter {
                 outputDirectory: outputDirectory,
                 embedImages: embedImages,
                 defaultSamplerIndex: defaultSamplerIndex,
-                repackAsMetallicRoughness: false
+                repackAsMetallicRoughness: false,
+                stampedImages: &stampedImages
             ) {
                 occlusionTexture = GLTFOcclusionTextureInfo(index: textureIndex, strength: 1)
             }
@@ -404,7 +476,9 @@ enum USDZToGLTFConverter {
         outputDirectory: URL,
         embedImages: Bool,
         defaultSamplerIndex: Int,
-        repackAsMetallicRoughness: Bool
+        repackAsMetallicRoughness: Bool,
+        watermark: WatermarkStamp? = nil,
+        stampedImages: inout [WatermarkRecord.TextureChannelInfo.Image]
     ) -> Int? {
         guard let property = material.property(with: semantic),
               property.type == .texture,
@@ -415,9 +489,23 @@ enum USDZToGLTFConverter {
             return existing
         }
 
-        guard let imageData = encodeTexture(texture, repackAsMetallicRoughness: repackAsMetallicRoughness) else {
+        guard var imageData = encodeTexture(texture, repackAsMetallicRoughness: repackAsMetallicRoughness) else {
             logger.warning("Skipping texture \(texture.name, privacy: .public)")
             return nil
+        }
+
+        // Only the base color carries the texture watermark; stamping normal,
+        // AO, or roughness maps harms shading for little forensic value.
+        if let watermark, semantic == .baseColor {
+            let name = sanitizedTextureFilename(texture.name, semantic: semantic)
+            if let stamped = WatermarkingService.stampedTexture(
+                pngData: imageData, name: name, stamp: watermark
+            ) {
+                imageData = stamped.data
+                stampedImages.append(stamped.image)
+            } else {
+                logger.warning("Texture watermark skipped for \(name, privacy: .public): payload not decodable.")
+            }
         }
 
         let mimeType = "image/png"
@@ -550,15 +638,27 @@ enum USDZToGLTFConverter {
 
 enum ModelExportService {
 
+    /// One derived-format export, with its provenance record when the file
+    /// was watermarked.
+    struct ExportedFile {
+        let url: URL
+        let format: ModelExportFormat
+        let detailLevel: CodableDetailLevel
+        let record: WatermarkRecord?
+    }
+
     /// Export all completed USDZ outputs for a job into the requested formats.
-  nonisolated static func exportCompletedOutputs(
+    /// With `embedWatermark`, each exported file is stamped with its own fresh
+    /// per-copy key and returns a record for the caller to persist.
+    nonisolated static func exportCompletedOutputs(
         for job: ReconstructionJob,
         formats: Set<ModelExportFormat>,
-        fileManager: FileManager = .default
-    ) throws -> [URL] {
+        fileManager: FileManager = .default,
+        embedWatermark: Bool = false
+    ) throws -> [ExportedFile] {
         guard !formats.isEmpty else { return [] }
 
-        var exportedURLs: [URL] = []
+        var exportedFiles: [ExportedFile] = []
         var exportErrors: [Error] = []
 
         for level in job.requestedDetailLevels {
@@ -567,18 +667,39 @@ enum ModelExportService {
 
             for format in formats.sorted(by: { $0.rawValue < $1.rawValue }) {
                 let outputURL = job.exportURL(for: level, format: format)
+                let stamp = embedWatermark ? WatermarkStamp.fresh() : nil
                 do {
+                    let outcome: WatermarkStampOutcome
                     switch format {
                     case .gaussianSplat:
-                        try SplatSampleGenerator.generate(usdzURL: usdzURL, outputURL: outputURL)
+                        outcome = try SplatSampleGenerator.generate(
+                            usdzURL: usdzURL,
+                            outputURL: outputURL,
+                            watermark: stamp
+                        )
                     case .gltf, .glb:
-                        try USDZToGLTFConverter.convert(
+                        outcome = try USDZToGLTFConverter.convert(
                             usdzURL: usdzURL,
                             format: format,
-                            outputURL: outputURL
+                            outputURL: outputURL,
+                            watermark: stamp
                         )
                     }
-                    exportedURLs.append(outputURL)
+
+                    var record: WatermarkRecord?
+                    if let stamp {
+                        record = try? WatermarkingService.record(
+                            for: stamp,
+                            outcome: outcome,
+                            jobId: job.id,
+                            detailLevel: level,
+                            format: format.fileExtension,
+                            fileURL: outputURL
+                        )
+                    }
+                    exportedFiles.append(ExportedFile(
+                        url: outputURL, format: format, detailLevel: level, record: record
+                    ))
                 } catch {
                     exportErrors.append(error)
                     logger.warning("Export failed for \(outputURL.lastPathComponent): \(error.localizedDescription)")
@@ -586,10 +707,10 @@ enum ModelExportService {
             }
         }
 
-        if exportedURLs.isEmpty, let firstError = exportErrors.first {
+        if exportedFiles.isEmpty, let firstError = exportErrors.first {
             throw firstError
         }
 
-        return exportedURLs
+        return exportedFiles
     }
 }

--- a/ObjectCaptureReconstruction/Export/USDZToGLTFConverter.swift
+++ b/ObjectCaptureReconstruction/Export/USDZToGLTFConverter.swift
@@ -688,14 +688,26 @@ enum ModelExportService {
 
                     var record: WatermarkRecord?
                     if let stamp {
-                        record = try? WatermarkingService.record(
-                            for: stamp,
-                            outcome: outcome,
-                            jobId: job.id,
-                            detailLevel: level,
-                            format: format.fileExtension,
-                            fileURL: outputURL
-                        )
+                        // A watermarked export without a record is untraceable:
+                        // remove the file and fail this export rather than
+                        // silently breaking the provenance guarantee.
+                        do {
+                            record = try WatermarkingService.record(
+                                for: stamp,
+                                outcome: outcome,
+                                jobId: job.id,
+                                detailLevel: level,
+                                format: format.fileExtension,
+                                fileURL: outputURL
+                            )
+                        } catch {
+                            try? fileManager.removeItem(at: outputURL)
+                            throw error
+                        }
+                        guard record != nil else {
+                            try? fileManager.removeItem(at: outputURL)
+                            throw WatermarkingError.nothingEmbedded(outputURL.lastPathComponent)
+                        }
                     }
                     exportedFiles.append(ExportedFile(
                         url: outputURL, format: format, detailLevel: level, record: record

--- a/ObjectCaptureReconstruction/Export/USDZToGLTFConverter.swift
+++ b/ObjectCaptureReconstruction/Export/USDZToGLTFConverter.swift
@@ -638,6 +638,12 @@ enum USDZToGLTFConverter {
 
 enum ModelExportService {
 
+    /// Identifies one derived output slot of a job.
+    struct ExportSlot: Hashable, Sendable {
+        let detailLevel: CodableDetailLevel
+        let format: ModelExportFormat
+    }
+
     /// One derived-format export, with its provenance record when the file
     /// was watermarked.
     struct ExportedFile {
@@ -645,16 +651,28 @@ enum ModelExportService {
         let format: ModelExportFormat
         let detailLevel: CodableDetailLevel
         let record: WatermarkRecord?
+        /// True when an already-current watermarked file was left in place
+        /// instead of being re-exported under a new key.
+        var isUpToDate: Bool = false
     }
 
     /// Export all completed USDZ outputs for a job into the requested formats.
     /// With `embedWatermark`, each exported file is stamped with its own fresh
     /// per-copy key and returns a record for the caller to persist.
+    ///
+    /// `recordedHashes` makes re-finalizing idempotent: a slot whose file on
+    /// disk still matches the hash of its newest provenance record is left
+    /// untouched, so a retry cannot silently re-key files that are already
+    /// marked and recorded.
+    /// `sharedKey` reuses one saved library key for every file instead of the
+    /// default fresh per-copy key.
     nonisolated static func exportCompletedOutputs(
         for job: ReconstructionJob,
         formats: Set<ModelExportFormat>,
         fileManager: FileManager = .default,
-        embedWatermark: Bool = false
+        embedWatermark: Bool = false,
+        sharedKey: SharedWatermarkKey? = nil,
+        recordedHashes: [ExportSlot: String] = [:]
     ) throws -> [ExportedFile] {
         guard !formats.isEmpty else { return [] }
 
@@ -667,7 +685,20 @@ enum ModelExportService {
 
             for format in formats.sorted(by: { $0.rawValue < $1.rawValue }) {
                 let outputURL = job.exportURL(for: level, format: format)
-                let stamp = embedWatermark ? WatermarkStamp.fresh() : nil
+
+                if let recordedHash = recordedHashes[ExportSlot(detailLevel: level, format: format)],
+                   fileManager.fileExists(atPath: outputURL.path),
+                   let currentHash = try? WatermarkingService.sha256Hex(of: outputURL),
+                   currentHash == recordedHash {
+                    exportedFiles.append(ExportedFile(
+                        url: outputURL, format: format, detailLevel: level,
+                        record: nil, isUpToDate: true
+                    ))
+                    logger.log("Skipped \(outputURL.lastPathComponent): already exported and recorded.")
+                    continue
+                }
+
+                let stamp = embedWatermark ? WatermarkStamp.next(sharedKey: sharedKey) : nil
                 do {
                     let outcome: WatermarkStampOutcome
                     switch format {

--- a/ObjectCaptureReconstruction/GaussianSplat/SplatSampleGenerator.swift
+++ b/ObjectCaptureReconstruction/GaussianSplat/SplatSampleGenerator.swift
@@ -9,6 +9,7 @@ conversion (training-free), not a photometrically optimized 3DGS.
 */
 
 import Foundation
+import WatermarkCore
 import simd
 import os
 
@@ -43,11 +44,15 @@ enum SplatSampleGenerator {
     /// Sample `usdzURL`'s surface and write a Gaussian-splat `.ply` to `outputURL`.
     /// - Parameter targetCount: number of splats to generate (clamped to a floor).
     ///   Exposed for testing; production callers use the fixed default.
+    /// - Parameter watermark: when set, the splat positions are stamped with
+    ///   the per-copy key (geometry channel only — splat color carries no mark).
+    @discardableResult
     nonisolated static func generate(
         usdzURL: URL,
         outputURL: URL,
-        targetCount: Int = defaultPointCount
-    ) throws {
+        targetCount: Int = defaultPointCount,
+        watermark: WatermarkStamp? = nil
+    ) throws -> WatermarkStampOutcome {
         let meshes = MeshGeometryReader.loadMeshes(from: usdzURL)
         guard !meshes.isEmpty else { throw GeneratorError.noGeometry(usdzURL) }
 
@@ -55,6 +60,25 @@ enum SplatSampleGenerator {
         let result = SurfaceSampler.sample(meshes: meshes, targetCount: count)
         guard !result.points.isEmpty, result.totalArea > 0 else {
             throw GeneratorError.noGeometry(usdzURL)
+        }
+
+        var positions = result.points.map(\.position)
+        var geometryInfo: WatermarkRecord.GeometryChannelInfo?
+        if let watermark {
+            let embedResult = GeometryWatermarker.embed(
+                positions: &positions,
+                key: watermark.key,
+                parameters: watermark.geometryParameters
+            )
+            if embedResult.isEmbedded {
+                geometryInfo = WatermarkRecord.GeometryChannelInfo(
+                    parameters: watermark.geometryParameters,
+                    effectiveBinCount: embedResult.effectiveBinCount,
+                    embeddedBits: embedResult.embeddedBits
+                )
+            } else {
+                logger.log("Geometry watermark skipped for \(outputURL.lastPathComponent, privacy: .public): too few points.")
+            }
         }
 
         // One color sampler per flattened material, in the same mesh-major/submesh
@@ -72,7 +96,7 @@ enum SplatSampleGenerator {
 
         var splats = [GaussianSplat]()
         splats.reserveCapacity(result.points.count)
-        for point in result.points {
+        for (index, point) in result.points.enumerated() {
             let color: SIMD3<Float>
             if point.materialIndex >= 0, point.materialIndex < colorSamplers.count {
                 color = colorSamplers[point.materialIndex].color(at: point.uv)
@@ -81,7 +105,7 @@ enum SplatSampleGenerator {
             }
 
             splats.append(GaussianSplat.surfaceSplat(
-                position: point.position,
+                position: positions[index],
                 normal: point.normal,
                 color: color,
                 tangentScale: tangentScale,
@@ -92,5 +116,6 @@ enum SplatSampleGenerator {
 
         try SplatPLYWriter.write(splats, to: outputURL)
         logger.log("Generated splat \(outputURL.lastPathComponent, privacy: .public) with \(splats.count) points from \(usdzURL.lastPathComponent, privacy: .public)")
+        return WatermarkStampOutcome(geometry: geometryInfo, texture: nil)
     }
 }

--- a/ObjectCaptureReconstruction/Models/JobDraft.swift
+++ b/ObjectCaptureReconstruction/Models/JobDraft.swift
@@ -42,6 +42,8 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
     var detailLevelOptionsUnderAdvancedMenu = CodableDetailLevelOptions()
     var exportFormats: Set<ModelExportFormat> = []
     var embedWatermark = false
+    /// Selected saved key; nil means a fresh per-copy key per exported file.
+    var watermarkKeyId: UUID?
 
     // MARK: - Error surface (used by ImageFolderView, ModelFolderView, etc.)
 
@@ -65,6 +67,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
         detailLevelOptionsUnderAdvancedMenu = job.additionalDetailLevels
         exportFormats = job.exportFormats
         embedWatermark = job.isWatermarkEnabled
+        watermarkKeyId = job.watermarkKeyId
     }
 
     // MARK: - Conversion
@@ -89,6 +92,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
         job.boundingBoxAvailable = boundingBoxAvailable
         job.exportFormats = exportFormats
         job.watermarkEnabled = embedWatermark
+        job.watermarkKeyId = embedWatermark ? watermarkKeyId : nil
         return job
     }
 

--- a/ObjectCaptureReconstruction/Models/JobDraft.swift
+++ b/ObjectCaptureReconstruction/Models/JobDraft.swift
@@ -41,6 +41,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
     var detailLevelOptionUnderQualityMenu: PhotogrammetrySession.Request.Detail = .medium
     var detailLevelOptionsUnderAdvancedMenu = CodableDetailLevelOptions()
     var exportFormats: Set<ModelExportFormat> = []
+    var embedWatermark = false
 
     // MARK: - Error surface (used by ImageFolderView, ModelFolderView, etc.)
 
@@ -63,6 +64,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
         detailLevelOptionUnderQualityMenu = job.primaryDetailLevel.toFrameworkType
         detailLevelOptionsUnderAdvancedMenu = job.additionalDetailLevels
         exportFormats = job.exportFormats
+        embedWatermark = job.isWatermarkEnabled
     }
 
     // MARK: - Conversion
@@ -86,6 +88,7 @@ private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
         )
         job.boundingBoxAvailable = boundingBoxAvailable
         job.exportFormats = exportFormats
+        job.watermarkEnabled = embedWatermark
         return job
     }
 

--- a/ObjectCaptureReconstruction/Models/PersistentExportRecord.swift
+++ b/ObjectCaptureReconstruction/Models/PersistentExportRecord.swift
@@ -1,0 +1,72 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+SwiftData model for provenance-watermark export records. One record per
+watermarked exported file, holding the per-copy secret key and the embedding
+parameters needed for later verification. Records are append-only provenance
+history: they intentionally survive job deletion.
+*/
+
+import Foundation
+import SwiftData
+import WatermarkCore
+
+@Model
+final class PersistentExportRecord {
+    @Attribute(.unique) var recordId: UUID
+    var jobId: UUID
+    var formatRawValue: String
+    var detailLevelRawValue: String
+    var filename: String
+    var filePath: String
+    var keyData: Data
+    var createdAt: Date
+    var schemaVersion: Int
+    var algorithmVersion: Int
+    var channelsData: Data
+    var geometryInfoData: Data?
+    var textureInfoData: Data?
+    var fileSHA256: String
+
+    init(record: WatermarkRecord) throws {
+        recordId = record.recordId
+        jobId = record.jobId
+        formatRawValue = record.format
+        detailLevelRawValue = record.detailLevel
+        filename = record.filename
+        filePath = record.filePath ?? ""
+        keyData = record.key
+        createdAt = record.createdAt
+        schemaVersion = record.schemaVersion
+        algorithmVersion = record.algorithmVersion
+        channelsData = try JSONEncoder().encode(record.channels)
+        geometryInfoData = try record.geometry.map { try JSONEncoder().encode($0) }
+        textureInfoData = try record.texture.map { try JSONEncoder().encode($0) }
+        fileSHA256 = record.fileSHA256
+    }
+
+    func toRecord() throws -> WatermarkRecord {
+        var record = WatermarkRecord(
+            recordId: recordId,
+            jobId: jobId,
+            format: formatRawValue,
+            detailLevel: detailLevelRawValue,
+            filename: filename,
+            filePath: filePath.isEmpty ? nil : filePath,
+            createdAt: createdAt,
+            key: try WatermarkKey(data: keyData),
+            channels: try JSONDecoder().decode([String].self, from: channelsData),
+            geometry: try geometryInfoData.map {
+                try JSONDecoder().decode(WatermarkRecord.GeometryChannelInfo.self, from: $0)
+            },
+            texture: try textureInfoData.map {
+                try JSONDecoder().decode(WatermarkRecord.TextureChannelInfo.self, from: $0)
+            },
+            fileSHA256: fileSHA256
+        )
+        record.schemaVersion = schemaVersion
+        record.algorithmVersion = algorithmVersion
+        return record
+    }
+}

--- a/ObjectCaptureReconstruction/Models/PersistentExportRecord.swift
+++ b/ObjectCaptureReconstruction/Models/PersistentExportRecord.swift
@@ -21,6 +21,9 @@ final class PersistentExportRecord {
     var filename: String
     var filePath: String
     var keyData: Data
+    /// Label when a reused library key produced this file; nil for a fresh
+    /// per-copy key.
+    var keyLabel: String?
     var createdAt: Date
     var schemaVersion: Int
     var algorithmVersion: Int
@@ -37,6 +40,7 @@ final class PersistentExportRecord {
         filename = record.filename
         filePath = record.filePath ?? ""
         keyData = record.key
+        keyLabel = record.keyLabel
         createdAt = record.createdAt
         schemaVersion = record.schemaVersion
         algorithmVersion = record.algorithmVersion
@@ -56,6 +60,7 @@ final class PersistentExportRecord {
             filePath: filePath.isEmpty ? nil : filePath,
             createdAt: createdAt,
             key: try WatermarkKey(data: keyData),
+            keyLabel: keyLabel,
             channels: try JSONDecoder().decode([String].self, from: channelsData),
             geometry: try geometryInfoData.map {
                 try JSONDecoder().decode(WatermarkRecord.GeometryChannelInfo.self, from: $0)

--- a/ObjectCaptureReconstruction/Models/PersistentJob.swift
+++ b/ObjectCaptureReconstruction/Models/PersistentJob.swift
@@ -27,6 +27,7 @@ final class PersistentJob {
     var completedOutputFilenamesData: Data?
     var exportFormatsData: Data?
     var watermarkEnabled: Bool?
+    var watermarkKeyId: UUID?
     var imageFolderBookmark: Data?
     var modelFolderBookmark: Data?
 
@@ -48,6 +49,7 @@ final class PersistentJob {
         completedOutputFilenamesData = try JSONEncoder().encode(job.completedOutputFilenames ?? [])
         exportFormatsData = try JSONEncoder().encode(job.exportFormats)
         watermarkEnabled = job.watermarkEnabled
+        watermarkKeyId = job.watermarkKeyId
         imageFolderBookmark = job.imageFolderBookmark
         modelFolderBookmark = job.modelFolderBookmark
     }
@@ -71,6 +73,7 @@ final class PersistentJob {
         completedOutputFilenamesData = try JSONEncoder().encode(job.completedOutputFilenames ?? [])
         exportFormatsData = try JSONEncoder().encode(job.exportFormats)
         watermarkEnabled = job.watermarkEnabled
+        watermarkKeyId = job.watermarkKeyId
         imageFolderBookmark = job.imageFolderBookmark
         modelFolderBookmark = job.modelFolderBookmark
     }
@@ -107,6 +110,7 @@ final class PersistentJob {
             completedOutputFilenames: completedOutputFilenames,
             exportFormats: exportFormats,
             watermarkEnabled: watermarkEnabled,
+            watermarkKeyId: watermarkKeyId,
             imageFolderBookmark: imageFolderBookmark,
             modelFolderBookmark: modelFolderBookmark
         )

--- a/ObjectCaptureReconstruction/Models/PersistentJob.swift
+++ b/ObjectCaptureReconstruction/Models/PersistentJob.swift
@@ -26,6 +26,7 @@ final class PersistentJob {
     var updatedAt: Date
     var completedOutputFilenamesData: Data?
     var exportFormatsData: Data?
+    var watermarkEnabled: Bool?
     var imageFolderBookmark: Data?
     var modelFolderBookmark: Data?
 
@@ -46,6 +47,7 @@ final class PersistentJob {
         updatedAt = Date()
         completedOutputFilenamesData = try JSONEncoder().encode(job.completedOutputFilenames ?? [])
         exportFormatsData = try JSONEncoder().encode(job.exportFormats)
+        watermarkEnabled = job.watermarkEnabled
         imageFolderBookmark = job.imageFolderBookmark
         modelFolderBookmark = job.modelFolderBookmark
     }
@@ -68,6 +70,7 @@ final class PersistentJob {
         updatedAt = Date()
         completedOutputFilenamesData = try JSONEncoder().encode(job.completedOutputFilenames ?? [])
         exportFormatsData = try JSONEncoder().encode(job.exportFormats)
+        watermarkEnabled = job.watermarkEnabled
         imageFolderBookmark = job.imageFolderBookmark
         modelFolderBookmark = job.modelFolderBookmark
     }
@@ -103,6 +106,7 @@ final class PersistentJob {
             createdAt: createdAt,
             completedOutputFilenames: completedOutputFilenames,
             exportFormats: exportFormats,
+            watermarkEnabled: watermarkEnabled,
             imageFolderBookmark: imageFolderBookmark,
             modelFolderBookmark: modelFolderBookmark
         )

--- a/ObjectCaptureReconstruction/Models/PersistentWatermarkKey.swift
+++ b/ObjectCaptureReconstruction/Models/PersistentWatermarkKey.swift
@@ -1,0 +1,46 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+SwiftData model for the labeled watermark key library. A saved key can be
+reused across jobs (an ownership stamp shared by many copies) instead of the
+default of a fresh per-copy key for every exported file.
+*/
+
+import Foundation
+import SwiftData
+import WatermarkCore
+
+@Model
+final class PersistentWatermarkKey {
+    @Attribute(.unique) var id: UUID
+    @Attribute(.unique) var label: String
+    var keyData: Data
+    var createdAt: Date
+    var lastUsedAt: Date?
+
+    init(id: UUID = UUID(), label: String, key: WatermarkKey, createdAt: Date = Date()) {
+        self.id = id
+        self.label = label
+        self.keyData = key.data
+        self.createdAt = createdAt
+        self.lastUsedAt = nil
+    }
+
+    var watermarkKey: WatermarkKey? {
+        try? WatermarkKey(data: keyData)
+    }
+
+    var info: WatermarkKeyInfo {
+        WatermarkKeyInfo(id: id, label: label, createdAt: createdAt, lastUsedAt: lastUsedAt)
+    }
+}
+
+/// Key metadata for the UI. Deliberately carries no key material — views never
+/// need it and should never display or leak it.
+struct WatermarkKeyInfo: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let label: String
+    let createdAt: Date
+    let lastUsedAt: Date?
+}

--- a/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
+++ b/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
@@ -31,6 +31,10 @@ struct ReconstructionJob: Identifiable, Codable {
     /// Optional so jobs persisted before this field existed still decode.
     var watermarkEnabled: Bool?
 
+    /// Saved library key to reuse for this job's exports. Nil means the
+    /// default: a fresh per-copy key for every exported file.
+    var watermarkKeyId: UUID?
+
     var isWatermarkEnabled: Bool { watermarkEnabled ?? false }
 
     /// Security-scoped bookmark data for persisting sandbox access across launches.
@@ -53,6 +57,7 @@ struct ReconstructionJob: Identifiable, Codable {
         completedOutputFilenames: Set<String>? = [],
         exportFormats: Set<ModelExportFormat> = [],
         watermarkEnabled: Bool? = nil,
+        watermarkKeyId: UUID? = nil,
         imageFolderBookmark: Data? = nil,
         modelFolderBookmark: Data? = nil
     ) {
@@ -71,6 +76,7 @@ struct ReconstructionJob: Identifiable, Codable {
         self.completedOutputFilenames = completedOutputFilenames
         self.exportFormats = exportFormats
         self.watermarkEnabled = watermarkEnabled
+        self.watermarkKeyId = watermarkKeyId
 
         self.imageFolderBookmark = imageFolderBookmark ?? (try? imageFolder.bookmarkData(
             options: .withSecurityScope,

--- a/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
+++ b/ObjectCaptureReconstruction/Models/ReconstructionJob.swift
@@ -28,6 +28,11 @@ struct ReconstructionJob: Identifiable, Codable {
     var completedOutputFilenames: Set<String>?
     var exportFormats: Set<ModelExportFormat> = []
 
+    /// Optional so jobs persisted before this field existed still decode.
+    var watermarkEnabled: Bool?
+
+    var isWatermarkEnabled: Bool { watermarkEnabled ?? false }
+
     /// Security-scoped bookmark data for persisting sandbox access across launches.
     var imageFolderBookmark: Data?
     var modelFolderBookmark: Data?
@@ -47,6 +52,7 @@ struct ReconstructionJob: Identifiable, Codable {
         createdAt: Date = Date(),
         completedOutputFilenames: Set<String>? = [],
         exportFormats: Set<ModelExportFormat> = [],
+        watermarkEnabled: Bool? = nil,
         imageFolderBookmark: Data? = nil,
         modelFolderBookmark: Data? = nil
     ) {
@@ -64,6 +70,7 @@ struct ReconstructionJob: Identifiable, Codable {
         self.createdAt = createdAt
         self.completedOutputFilenames = completedOutputFilenames
         self.exportFormats = exportFormats
+        self.watermarkEnabled = watermarkEnabled
 
         self.imageFolderBookmark = imageFolderBookmark ?? (try? imageFolder.bookmarkData(
             options: .withSecurityScope,

--- a/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
+++ b/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
@@ -183,7 +183,16 @@ struct QueueDashboardView: View {
                     exportErrorMessage = "No completed USDZ outputs were available to export."
                     return
                 }
-                appDataModel.scheduler.saveExportRecords(exportedFiles.compactMap(\.record))
+                let markedFiles = exportedFiles.filter { $0.record != nil }
+                guard appDataModel.scheduler.saveExportRecords(markedFiles.compactMap(\.record)) else {
+                    // Without persisted keys the marked exports are
+                    // untraceable — remove them and tell the user.
+                    for file in markedFiles {
+                        try? FileManager.default.removeItem(at: file.url)
+                    }
+                    exportErrorMessage = "Export succeeded, but the provenance records could not be saved. The exported files were removed — try again."
+                    return
+                }
                 NSWorkspace.shared.activateFileViewerSelecting(exportedFiles.map(\.url))
             } catch {
                 exportErrorMessage = error.localizedDescription

--- a/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
+++ b/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
@@ -177,7 +177,8 @@ struct QueueDashboardView: View {
                 let exportedFiles = try ModelExportService.exportCompletedOutputs(
                     for: workingJob,
                     formats: [format],
-                    embedWatermark: workingJob.isWatermarkEnabled
+                    embedWatermark: workingJob.isWatermarkEnabled,
+                    sharedKey: appDataModel.scheduler.sharedWatermarkKey(for: workingJob)
                 )
                 guard !exportedFiles.isEmpty else {
                     exportErrorMessage = "No completed USDZ outputs were available to export."

--- a/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
+++ b/ObjectCaptureReconstruction/Queue/QueueDashboardView.swift
@@ -87,6 +87,15 @@ struct QueueDashboardView: View {
                                 }
                                 .disabled(isExporting)
                             }
+
+                            // Internal tooling, hidden unless enabled via
+                            // `defaults write <bundle-id> RPWatermarkRecordExport -bool YES`.
+                            // Record JSONs contain the per-copy secret keys.
+                            if UserDefaults.standard.bool(forKey: "RPWatermarkRecordExport") {
+                                Button("Export Provenance Records…") {
+                                    exportProvenanceRecords(for: job)
+                                }
+                            }
                         }
 
                         Divider()
@@ -165,18 +174,48 @@ struct QueueDashboardView: View {
             }
 
             do {
-                let exportedURLs = try ModelExportService.exportCompletedOutputs(
+                let exportedFiles = try ModelExportService.exportCompletedOutputs(
                     for: workingJob,
-                    formats: [format]
+                    formats: [format],
+                    embedWatermark: workingJob.isWatermarkEnabled
                 )
-                guard !exportedURLs.isEmpty else {
+                guard !exportedFiles.isEmpty else {
                     exportErrorMessage = "No completed USDZ outputs were available to export."
                     return
                 }
-                NSWorkspace.shared.activateFileViewerSelecting(exportedURLs)
+                appDataModel.scheduler.saveExportRecords(exportedFiles.compactMap(\.record))
+                NSWorkspace.shared.activateFileViewerSelecting(exportedFiles.map(\.url))
             } catch {
                 exportErrorMessage = error.localizedDescription
             }
+        }
+    }
+
+    /// Internal: dump this job's provenance records as JSON for the offline
+    /// `watermark-verify` tool. Each file contains a per-copy secret key.
+    private func exportProvenanceRecords(for job: ReconstructionJob) {
+        let records = appDataModel.scheduler.exportRecords(jobId: job.id)
+        guard !records.isEmpty else {
+            exportErrorMessage = "No provenance records exist for this job."
+            return
+        }
+
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Export Records"
+        panel.message = "Choose a folder for the record files. They contain secret watermark keys — keep them private."
+        guard panel.runModal() == .OK, let directory = panel.url else { return }
+
+        do {
+            for record in records {
+                let url = directory.appending(path: "\(record.filename).wmrecord.json")
+                try record.jsonData().write(to: url, options: [.atomic])
+            }
+            NSWorkspace.shared.activateFileViewerSelecting([directory])
+        } catch {
+            exportErrorMessage = "Failed to write records: \(error.localizedDescription)"
         }
     }
 }

--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -9,6 +9,7 @@ respecting optional time-window constraints.
 import Foundation
 import RealityKit
 import UserNotifications
+import WatermarkCore
 import os
 
 private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
@@ -397,7 +398,7 @@ class JobScheduler {
             } else if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
                 jobs[idx].status = .completed
                 jobs[idx].progress = 1.0
-                let notificationBody = exportAdditionalFormats(for: jobs[idx]) ?? jobName
+                let notificationBody = finalizeCompletedJob(for: jobs[idx]) ?? jobName
                 sendNotification(title: "Job Complete", body: notificationBody)
             }
 
@@ -446,20 +447,82 @@ class JobScheduler {
         job.markOutputCompleted(at: url)
     }
 
+    /// Post-reconstruction finalize, in a deliberate order: derived formats
+    /// are converted first (from the still-pristine USDZ, so they never
+    /// inherit its marks), then the USDZ itself is texture-stamped last.
+    private func finalizeCompletedJob(for job: ReconstructionJob) -> String? {
+        let exportSummary = exportAdditionalFormats(for: job)
+        stampCompletedUSDZOutputs(for: job)
+        return exportSummary
+    }
+
+    private func stampCompletedUSDZOutputs(for job: ReconstructionJob) {
+        guard job.isWatermarkEnabled else { return }
+
+        for level in job.requestedDetailLevels where job.hasCompletedOutputFile(for: level) {
+            let usdzURL = job.outputURL(for: level)
+
+            // Idempotence across retries: skip when the newest usdz record
+            // still matches the file bytes (already stamped, unchanged).
+            if let existing = store.latestExportRecord(
+                jobId: job.id, detailLevel: level.rawValue, format: "usdz"
+               ),
+               let currentSHA = try? WatermarkingService.sha256Hex(of: usdzURL),
+               currentSHA == existing.fileSHA256 {
+                continue
+            }
+
+            let stamp = WatermarkStamp.fresh()
+            do {
+                let result = try USDZStamper.stampTextures(usdzURL: usdzURL, stamp: stamp)
+                let record = WatermarkRecord(
+                    jobId: job.id,
+                    format: "usdz",
+                    detailLevel: level.rawValue,
+                    filename: usdzURL.lastPathComponent,
+                    filePath: usdzURL.path,
+                    key: stamp.key,
+                    channels: [WatermarkRecord.Channel.texture],
+                    geometry: nil,
+                    texture: WatermarkRecord.TextureChannelInfo(
+                        parameters: stamp.textureParameters,
+                        images: result.stampedImages
+                    ),
+                    fileSHA256: result.fileSHA256
+                )
+                store.saveExportRecords([record])
+            } catch {
+                logger.warning("USDZ provenance stamp failed for \(usdzURL.lastPathComponent, privacy: .public): \(error.localizedDescription)")
+            }
+        }
+    }
+
     private func exportAdditionalFormats(for job: ReconstructionJob) -> String? {
         guard !job.exportFormats.isEmpty else { return nil }
 
         do {
-            let exportedURLs = try ModelExportService.exportCompletedOutputs(
+            let exportedFiles = try ModelExportService.exportCompletedOutputs(
                 for: job,
-                formats: job.exportFormats
+                formats: job.exportFormats,
+                embedWatermark: job.isWatermarkEnabled
             )
-            guard !exportedURLs.isEmpty else { return nil }
-            return "\(job.modelName) — exported \(exportedURLs.count) additional file(s)"
+            guard !exportedFiles.isEmpty else { return nil }
+            store.saveExportRecords(exportedFiles.compactMap(\.record))
+            return "\(job.modelName) — exported \(exportedFiles.count) additional file(s)"
         } catch {
             logger.warning("Additional format export failed for \(job.modelName): \(error.localizedDescription)")
             return "\(job.modelName) — reconstruction complete, but additional export failed"
         }
+    }
+
+    /// Persist provenance records produced by an export outside the scheduler
+    /// path (the dashboard's manual "Export As" flow).
+    func saveExportRecords(_ records: [WatermarkRecord]) {
+        store.saveExportRecords(records)
+    }
+
+    func exportRecords(jobId: UUID) -> [WatermarkRecord] {
+        store.exportRecords(jobId: jobId)
     }
 
     // MARK: - Session creation (nonisolated to avoid blocking main actor)

--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -323,7 +323,7 @@ class JobScheduler {
             // and provenance stamping silently never happen for this job.
             jobs[index].status = .completed
             jobs[index].progress = 1.0
-            let notificationBody = finalizeCompletedJob(for: jobs[index]) ?? jobName
+            let notificationBody = await finalizeCompletedJob(for: jobs[index]) ?? jobName
             sendNotification(title: "Job Complete", body: notificationBody)
             persist()
             return
@@ -402,7 +402,7 @@ class JobScheduler {
             } else if let idx = jobs.firstIndex(where: { $0.id == jobId }) {
                 jobs[idx].status = .completed
                 jobs[idx].progress = 1.0
-                let notificationBody = finalizeCompletedJob(for: jobs[idx]) ?? jobName
+                let notificationBody = await finalizeCompletedJob(for: jobs[idx]) ?? jobName
                 sendNotification(title: "Job Complete", body: notificationBody)
             }
 
@@ -456,50 +456,65 @@ class JobScheduler {
     /// inherit its marks), then the USDZ itself is texture-stamped last.
     /// Returns the notification body; stamping problems are surfaced there
     /// because the queue row only shows errors for failed jobs.
-    private func finalizeCompletedJob(for job: ReconstructionJob) -> String? {
-        let exportSummary = exportAdditionalFormats(for: job)
-        let stampWarning = stampCompletedUSDZOutputs(for: job)
+    private func finalizeCompletedJob(for job: ReconstructionJob) async -> String? {
+        let (sharedKey, keyWarning) = resolveSharedKey(for: job)
+        let exportSummary = await exportAdditionalFormats(for: job, sharedKey: sharedKey)
+        let stampWarning = await stampCompletedUSDZOutputs(for: job, sharedKey: sharedKey)
 
-        switch (exportSummary, stampWarning) {
-        case (nil, nil):
+        let warnings = [keyWarning, stampWarning].compactMap { $0 }
+        switch (exportSummary, warnings.isEmpty) {
+        case (nil, true):
             return nil
-        case (let summary?, nil):
+        case (let summary?, true):
             return summary
-        case (nil, let warning?):
-            return "\(job.modelName) — \(warning)"
-        case (let summary?, let warning?):
-            return "\(summary); \(warning)"
+        case (nil, false):
+            return "\(job.modelName) — \(warnings.joined(separator: "; "))"
+        case (let summary?, false):
+            return "\(summary); \(warnings.joined(separator: "; "))"
         }
+    }
+
+    /// Resolve the job's selected library key. A missing key (deleted since
+    /// the job was created) falls back to fresh per-copy keys — strictly more
+    /// traceable, but the user asked for the label, so it is surfaced.
+    private func resolveSharedKey(
+        for job: ReconstructionJob
+    ) -> (shared: SharedWatermarkKey?, warning: String?) {
+        guard job.isWatermarkEnabled, let keyId = job.watermarkKeyId else { return (nil, nil) }
+        guard let resolved = store.watermarkKey(id: keyId) else {
+            logger.warning("Saved watermark key \(keyId) is missing; falling back to per-copy keys.")
+            return (nil, "saved watermark key is missing, used fresh per-copy keys instead")
+        }
+        return (SharedWatermarkKey(key: resolved.key, label: resolved.label), nil)
     }
 
     /// Returns a user-facing warning when any stamp failed, nil when all
     /// stamps succeeded or watermarking is off.
-    private func stampCompletedUSDZOutputs(for job: ReconstructionJob) -> String? {
+    private func stampCompletedUSDZOutputs(
+        for job: ReconstructionJob,
+        sharedKey: SharedWatermarkKey?
+    ) async -> String? {
         guard job.isWatermarkEnabled else { return nil }
 
         var attempted = 0
         var failed = 0
         for level in job.requestedDetailLevels where job.hasCompletedOutputFile(for: level) {
             let usdzURL = job.outputURL(for: level)
-
-            // Idempotence across retries: skip when the newest usdz record
-            // still matches the file bytes (already stamped, unchanged).
-            if let existing = store.latestExportRecord(
+            let recordedSHA = store.latestExportRecord(
                 jobId: job.id, detailLevel: level.rawValue, format: "usdz"
-               ),
-               let currentSHA = try? WatermarkingService.sha256Hex(of: usdzURL),
-               currentSHA == existing.fileSHA256 {
-                continue
-            }
+            )?.fileSHA256
+            let stamp = WatermarkStamp.next(sharedKey: sharedKey)
 
-            attempted += 1
-            let stamp = WatermarkStamp.fresh()
             do {
-                // Stage, persist the record, then swap the file in — never
-                // the other way around: a marked file without a persisted
-                // key would be untraceable, and a later retry would stamp a
-                // second layer over it.
-                let staged = try USDZStamper.stage(usdzURL: usdzURL, stamp: stamp)
+                // Stage off the main actor, persist the record, then swap the
+                // file in — never the other way around: a marked file without
+                // a persisted key would be untraceable, and a later retry
+                // would stamp a second layer over it.
+                guard let staged = try await stageStampIfNeeded(
+                    usdzURL: usdzURL, recordedSHA: recordedSHA, stamp: stamp
+                ) else { continue }
+
+                attempted += 1
                 let record = WatermarkRecord(
                     jobId: job.id,
                     format: "usdz",
@@ -507,6 +522,7 @@ class JobScheduler {
                     filename: usdzURL.lastPathComponent,
                     filePath: usdzURL.path,
                     key: stamp.key,
+                    keyLabel: stamp.keyLabel,
                     channels: [WatermarkRecord.Channel.texture],
                     geometry: nil,
                     texture: WatermarkRecord.TextureChannelInfo(
@@ -520,8 +536,21 @@ class JobScheduler {
                     failed += 1
                     continue
                 }
-                try USDZStamper.commit(staged, to: usdzURL)
+
+                do {
+                    try USDZStamper.commit(staged, to: usdzURL)
+                } catch {
+                    // The record is saved but the file was never replaced.
+                    // Roll the record back, otherwise it would describe bytes
+                    // that do not exist and defeat the idempotence check on
+                    // the next retry.
+                    USDZStamper.discard(staged)
+                    store.deleteExportRecords(recordIds: [record.recordId])
+                    failed += 1
+                    logger.warning("USDZ provenance commit failed for \(usdzURL.lastPathComponent, privacy: .public): \(error.localizedDescription)")
+                }
             } catch {
+                attempted += 1
                 failed += 1
                 logger.warning("USDZ provenance stamp failed for \(usdzURL.lastPathComponent, privacy: .public): \(error.localizedDescription)")
             }
@@ -531,14 +560,34 @@ class JobScheduler {
         return "provenance stamping failed for \(failed) of \(attempted) USDZ file(s)"
     }
 
-    private func exportAdditionalFormats(for job: ReconstructionJob) -> String? {
+    private func exportAdditionalFormats(
+        for job: ReconstructionJob,
+        sharedKey: SharedWatermarkKey?
+    ) async -> String? {
         guard !job.exportFormats.isEmpty else { return nil }
 
+        // Idempotence: a slot whose file still matches its newest record is
+        // left alone, so re-finalizing (e.g. a retry where every USDZ already
+        // existed) cannot silently re-key files that are already traceable.
+        var recordedHashes: [ModelExportService.ExportSlot: String] = [:]
+        if job.isWatermarkEnabled {
+            for level in job.requestedDetailLevels {
+                for format in job.exportFormats {
+                    guard let record = store.latestExportRecord(
+                        jobId: job.id, detailLevel: level.rawValue, format: format.fileExtension
+                    ) else { continue }
+                    recordedHashes[.init(detailLevel: level, format: format)] = record.fileSHA256
+                }
+            }
+        }
+
         do {
-            let exportedFiles = try ModelExportService.exportCompletedOutputs(
-                for: job,
+            let exportedFiles = try await runExports(
+                job: job,
                 formats: job.exportFormats,
-                embedWatermark: job.isWatermarkEnabled
+                embedWatermark: job.isWatermarkEnabled,
+                sharedKey: sharedKey,
+                recordedHashes: recordedHashes
             )
             guard !exportedFiles.isEmpty else { return nil }
 
@@ -551,11 +600,50 @@ class JobScheduler {
                 }
                 return "\(job.modelName) — additional export failed: provenance records could not be saved"
             }
-            return "\(job.modelName) — exported \(exportedFiles.count) additional file(s)"
+
+            let freshCount = exportedFiles.filter { !$0.isUpToDate }.count
+            guard freshCount > 0 else { return nil }
+            return "\(job.modelName) — exported \(freshCount) additional file(s)"
         } catch {
             logger.warning("Additional format export failed for \(job.modelName): \(error.localizedDescription)")
             return "\(job.modelName) — reconstruction complete, but additional export failed"
         }
+    }
+
+    // MARK: - Finalize work (nonisolated to avoid blocking main actor)
+
+    /// Format conversion, watermark embedding, and hashing are all CPU- and
+    /// I/O-heavy (splat generation alone samples a million points), so they
+    /// run off the main actor like `createSession` does.
+    private nonisolated func runExports(
+        job: ReconstructionJob,
+        formats: Set<ModelExportFormat>,
+        embedWatermark: Bool,
+        sharedKey: SharedWatermarkKey?,
+        recordedHashes: [ModelExportService.ExportSlot: String]
+    ) async throws -> [ModelExportService.ExportedFile] {
+        try ModelExportService.exportCompletedOutputs(
+            for: job,
+            formats: formats,
+            embedWatermark: embedWatermark,
+            sharedKey: sharedKey,
+            recordedHashes: recordedHashes
+        )
+    }
+
+    /// Returns nil when the file already matches its recorded hash (nothing to
+    /// do), otherwise a staged copy awaiting record persistence and commit.
+    private nonisolated func stageStampIfNeeded(
+        usdzURL: URL,
+        recordedSHA: String?,
+        stamp: WatermarkStamp
+    ) async throws -> USDZStamper.StagedStamp? {
+        if let recordedSHA,
+           let currentSHA = try? WatermarkingService.sha256Hex(of: usdzURL),
+           currentSHA == recordedSHA {
+            return nil
+        }
+        return try USDZStamper.stage(usdzURL: usdzURL, stamp: stamp)
     }
 
     /// Persist provenance records produced by an export outside the scheduler
@@ -569,6 +657,23 @@ class JobScheduler {
 
     func exportRecords(jobId: UUID) -> [WatermarkRecord] {
         store.exportRecords(jobId: jobId)
+    }
+
+    // MARK: - Watermark key library
+
+    func watermarkKeys() -> [WatermarkKeyInfo] {
+        store.watermarkKeys()
+    }
+
+    /// Returns nil when the label is blank or already in use.
+    func createWatermarkKey(label: String) -> WatermarkKeyInfo? {
+        store.createWatermarkKey(label: label)
+    }
+
+    /// Resolve a job's selected library key for an export outside the
+    /// scheduler path (the dashboard's manual "Export As" flow).
+    func sharedWatermarkKey(for job: ReconstructionJob) -> SharedWatermarkKey? {
+        resolveSharedKey(for: job).shared
     }
 
     // MARK: - Session creation (nonisolated to avoid blocking main actor)

--- a/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
+++ b/ObjectCaptureReconstruction/Scheduler/JobScheduler.swift
@@ -318,9 +318,13 @@ class JobScheduler {
         }
 
         guard !requests.isEmpty else {
+            // All detail levels are already on disk (e.g. a retry after every
+            // USDZ was written) — finalize must still run, or derived exports
+            // and provenance stamping silently never happen for this job.
             jobs[index].status = .completed
             jobs[index].progress = 1.0
-            sendNotification(title: "Job Complete", body: jobName)
+            let notificationBody = finalizeCompletedJob(for: jobs[index]) ?? jobName
+            sendNotification(title: "Job Complete", body: notificationBody)
             persist()
             return
         }
@@ -450,15 +454,31 @@ class JobScheduler {
     /// Post-reconstruction finalize, in a deliberate order: derived formats
     /// are converted first (from the still-pristine USDZ, so they never
     /// inherit its marks), then the USDZ itself is texture-stamped last.
+    /// Returns the notification body; stamping problems are surfaced there
+    /// because the queue row only shows errors for failed jobs.
     private func finalizeCompletedJob(for job: ReconstructionJob) -> String? {
         let exportSummary = exportAdditionalFormats(for: job)
-        stampCompletedUSDZOutputs(for: job)
-        return exportSummary
+        let stampWarning = stampCompletedUSDZOutputs(for: job)
+
+        switch (exportSummary, stampWarning) {
+        case (nil, nil):
+            return nil
+        case (let summary?, nil):
+            return summary
+        case (nil, let warning?):
+            return "\(job.modelName) — \(warning)"
+        case (let summary?, let warning?):
+            return "\(summary); \(warning)"
+        }
     }
 
-    private func stampCompletedUSDZOutputs(for job: ReconstructionJob) {
-        guard job.isWatermarkEnabled else { return }
+    /// Returns a user-facing warning when any stamp failed, nil when all
+    /// stamps succeeded or watermarking is off.
+    private func stampCompletedUSDZOutputs(for job: ReconstructionJob) -> String? {
+        guard job.isWatermarkEnabled else { return nil }
 
+        var attempted = 0
+        var failed = 0
         for level in job.requestedDetailLevels where job.hasCompletedOutputFile(for: level) {
             let usdzURL = job.outputURL(for: level)
 
@@ -472,9 +492,14 @@ class JobScheduler {
                 continue
             }
 
+            attempted += 1
             let stamp = WatermarkStamp.fresh()
             do {
-                let result = try USDZStamper.stampTextures(usdzURL: usdzURL, stamp: stamp)
+                // Stage, persist the record, then swap the file in — never
+                // the other way around: a marked file without a persisted
+                // key would be untraceable, and a later retry would stamp a
+                // second layer over it.
+                let staged = try USDZStamper.stage(usdzURL: usdzURL, stamp: stamp)
                 let record = WatermarkRecord(
                     jobId: job.id,
                     format: "usdz",
@@ -486,15 +511,24 @@ class JobScheduler {
                     geometry: nil,
                     texture: WatermarkRecord.TextureChannelInfo(
                         parameters: stamp.textureParameters,
-                        images: result.stampedImages
+                        images: staged.stampedImages
                     ),
-                    fileSHA256: result.fileSHA256
+                    fileSHA256: staged.fileSHA256
                 )
-                store.saveExportRecords([record])
+                guard store.saveExportRecords([record]) else {
+                    USDZStamper.discard(staged)
+                    failed += 1
+                    continue
+                }
+                try USDZStamper.commit(staged, to: usdzURL)
             } catch {
+                failed += 1
                 logger.warning("USDZ provenance stamp failed for \(usdzURL.lastPathComponent, privacy: .public): \(error.localizedDescription)")
             }
         }
+
+        guard failed > 0 else { return nil }
+        return "provenance stamping failed for \(failed) of \(attempted) USDZ file(s)"
     }
 
     private func exportAdditionalFormats(for job: ReconstructionJob) -> String? {
@@ -507,7 +541,16 @@ class JobScheduler {
                 embedWatermark: job.isWatermarkEnabled
             )
             guard !exportedFiles.isEmpty else { return nil }
-            store.saveExportRecords(exportedFiles.compactMap(\.record))
+
+            let markedFiles = exportedFiles.filter { $0.record != nil }
+            guard store.saveExportRecords(markedFiles.compactMap(\.record)) else {
+                // Marked files whose keys were never persisted are
+                // untraceable — remove them rather than ship them silently.
+                for file in markedFiles {
+                    try? FileManager.default.removeItem(at: file.url)
+                }
+                return "\(job.modelName) — additional export failed: provenance records could not be saved"
+            }
             return "\(job.modelName) — exported \(exportedFiles.count) additional file(s)"
         } catch {
             logger.warning("Additional format export failed for \(job.modelName): \(error.localizedDescription)")
@@ -516,8 +559,11 @@ class JobScheduler {
     }
 
     /// Persist provenance records produced by an export outside the scheduler
-    /// path (the dashboard's manual "Export As" flow).
-    func saveExportRecords(_ records: [WatermarkRecord]) {
+    /// path (the dashboard's manual "Export As" flow). Returns false when the
+    /// records could not be saved — the caller must treat the marked files as
+    /// untraceable.
+    @discardableResult
+    func saveExportRecords(_ records: [WatermarkRecord]) -> Bool {
         store.saveExportRecords(records)
     }
 

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ReconstructionOptionsView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/ReconstructionOptionsView.swift
@@ -18,6 +18,8 @@ struct ReconstructionOptionsView: View {
 
         ExportFormatView()
 
+        WatermarkOptionView()
+
         OutputPreviewView()
 
         Divider()

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/WatermarkOptionView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/WatermarkOptionView.swift
@@ -1,0 +1,31 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Opt-in provenance watermarking for exported models.
+*/
+
+import SwiftUI
+
+struct WatermarkOptionView: View {
+    @Environment(JobDraft.self) private var draft: JobDraft
+
+    var body: some View {
+        @Bindable var draft = draft
+
+        GroupBox {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Provenance", systemImage: "checkmark.seal")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Toggle("Embed provenance watermark", isOn: $draft.embedWatermark)
+
+                Text("Imperceptibly marks each exported file with a per-copy secret key so copies found elsewhere can be traced to this export. Keys stay on this Mac.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/ObjectCaptureReconstruction/Settings/ReconstructionOptions/WatermarkOptionView.swift
+++ b/ObjectCaptureReconstruction/Settings/ReconstructionOptions/WatermarkOptionView.swift
@@ -2,13 +2,23 @@
 See the LICENSE.txt file for this sample's licensing information.
 
 Abstract:
-Opt-in provenance watermarking for exported models.
+Opt-in provenance watermarking for exported models, with an optional saved key
+that can be reused across jobs.
 */
 
 import SwiftUI
 
 struct WatermarkOptionView: View {
     @Environment(JobDraft.self) private var draft: JobDraft
+    @Environment(AppDataModel.self) private var appDataModel: AppDataModel
+
+    @State private var savedKeys: [WatermarkKeyInfo] = []
+    @State private var isNamingKey = false
+    @State private var newKeyLabel = ""
+    @State private var keyErrorMessage: String?
+
+    /// Sentinel for "generate a fresh key for every exported file".
+    private static let perCopyKeyTag: UUID? = nil
 
     var body: some View {
         @Bindable var draft = draft
@@ -21,11 +31,69 @@ struct WatermarkOptionView: View {
 
                 Toggle("Embed provenance watermark", isOn: $draft.embedWatermark)
 
-                Text("Imperceptibly marks each exported file with a per-copy secret key so copies found elsewhere can be traced to this export. Keys stay on this Mac.")
+                Text("Imperceptibly marks each exported file with a secret key so copies found elsewhere can be traced back to this export. Keys stay on this Mac.")
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
+
+                if draft.embedWatermark {
+                    Divider()
+
+                    Picker("Key", selection: $draft.watermarkKeyId) {
+                        Text("New key per file").tag(Self.perCopyKeyTag)
+                        if !savedKeys.isEmpty {
+                            Divider()
+                            ForEach(savedKeys) { key in
+                                Text(key.label).tag(Optional(key.id))
+                            }
+                        }
+                    }
+
+                    Text(keyExplanation)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+
+                    Button("New Saved Key…") {
+                        newKeyLabel = ""
+                        isNamingKey = true
+                    }
+                    .controlSize(.small)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .task { savedKeys = appDataModel.scheduler.watermarkKeys() }
+        .alert("New Saved Key", isPresented: $isNamingKey) {
+            TextField("Label (for example, a client or collection name)", text: $newKeyLabel)
+            Button("Create", action: createKey)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Every file marked with this key carries the same mark, so a leak traces back to the key rather than to one copy.")
+        }
+        .alert("Could Not Create Key", isPresented: Binding(
+            get: { keyErrorMessage != nil },
+            set: { if !$0 { keyErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(keyErrorMessage ?? "")
+        }
+    }
+
+    private var keyExplanation: String {
+        if draft.watermarkKeyId == nil {
+            return "Each exported file gets its own key, so a leaked copy identifies exactly which export it came from."
+        }
+        return "All files in this job share the saved key. A leaked copy proves it is yours, but not which copy leaked."
+    }
+
+    private func createKey() {
+        guard let created = appDataModel.scheduler.createWatermarkKey(label: newKeyLabel) else {
+            keyErrorMessage = newKeyLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "Enter a label for the key."
+                : "A key named “\(newKeyLabel)” already exists."
+            return
+        }
+        savedKeys = appDataModel.scheduler.watermarkKeys()
+        draft.watermarkKeyId = created.id
     }
 }

--- a/ObjectCaptureReconstruction/Store/JobStore.swift
+++ b/ObjectCaptureReconstruction/Store/JobStore.swift
@@ -142,8 +142,13 @@ class JobStore {
 
     /// Export records are append-only provenance history: they are never
     /// updated in place and intentionally survive job deletion.
-    func saveExportRecords(_ records: [WatermarkRecord]) {
-        guard !records.isEmpty else { return }
+    ///
+    /// Returns false when persistence failed — callers must treat the
+    /// affected files as unmarked, because a marked file whose key was never
+    /// recorded is untraceable.
+    @discardableResult
+    func saveExportRecords(_ records: [WatermarkRecord]) -> Bool {
+        guard !records.isEmpty else { return true }
         do {
             for record in records {
                 modelContext.insert(try PersistentExportRecord(record: record))
@@ -151,8 +156,11 @@ class JobStore {
             try saveIfNeeded()
             logger.log("Saved \(records.count) provenance export record(s).")
             lastErrorMessage = nil
+            return true
         } catch {
+            modelContext.rollback()
             recordError("Failed to save export records: \(error.localizedDescription)", error: error)
+            return false
         }
     }
 

--- a/ObjectCaptureReconstruction/Store/JobStore.swift
+++ b/ObjectCaptureReconstruction/Store/JobStore.swift
@@ -53,7 +53,8 @@ class JobStore {
             PersistentJob.self,
             PersistentScheduleSettings.self,
             PersistentMigrationState.self,
-            PersistentExportRecord.self
+            PersistentExportRecord.self,
+            PersistentWatermarkKey.self
         ])
         let configuration = ModelConfiguration(
             schema: schema,
@@ -164,6 +165,25 @@ class JobStore {
         }
     }
 
+    /// Remove records again — used to roll back when the file a record
+    /// describes could not be put in place after the record was saved.
+    func deleteExportRecords(recordIds: [UUID]) {
+        guard !recordIds.isEmpty else { return }
+        do {
+            let ids = Set(recordIds)
+            var descriptor = FetchDescriptor<PersistentExportRecord>(
+                predicate: #Predicate { ids.contains($0.recordId) }
+            )
+            descriptor.includePendingChanges = true
+            for record in try modelContext.fetch(descriptor) {
+                modelContext.delete(record)
+            }
+            try saveIfNeeded()
+        } catch {
+            recordError("Failed to roll back export records: \(error.localizedDescription)", error: error)
+        }
+    }
+
     func exportRecords(jobId: UUID) -> [WatermarkRecord] {
         do {
             var descriptor = FetchDescriptor<PersistentExportRecord>(
@@ -196,6 +216,86 @@ class JobStore {
         } catch {
             recordError("Failed to load export record: \(error.localizedDescription)", error: error)
             return nil
+        }
+    }
+
+    // MARK: - Watermark key library
+
+    /// Saved keys, most recently used first. Returns metadata only — key
+    /// material never leaves the store except through `watermarkKey(id:)`.
+    func watermarkKeys() -> [WatermarkKeyInfo] {
+        do {
+            var descriptor = FetchDescriptor<PersistentWatermarkKey>(
+                sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+            )
+            descriptor.includePendingChanges = true
+            return try modelContext.fetch(descriptor).map(\.info)
+        } catch {
+            recordError("Failed to load watermark keys: \(error.localizedDescription)", error: error)
+            return []
+        }
+    }
+
+    /// Create and save a new labeled key. Returns nil when the label is blank
+    /// or already taken.
+    func createWatermarkKey(label: String) -> WatermarkKeyInfo? {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        do {
+            var descriptor = FetchDescriptor<PersistentWatermarkKey>(
+                predicate: #Predicate { $0.label == trimmed }
+            )
+            descriptor.fetchLimit = 1
+            descriptor.includePendingChanges = true
+            guard try modelContext.fetch(descriptor).isEmpty else { return nil }
+
+            let saved = PersistentWatermarkKey(label: trimmed, key: .random())
+            modelContext.insert(saved)
+            try saveIfNeeded()
+            logger.log("Created watermark key '\(trimmed, privacy: .public)'.")
+            lastErrorMessage = nil
+            return saved.info
+        } catch {
+            modelContext.rollback()
+            recordError("Failed to create watermark key: \(error.localizedDescription)", error: error)
+            return nil
+        }
+    }
+
+    /// Resolve a saved key for embedding, marking it as used.
+    func watermarkKey(id: UUID) -> (key: WatermarkKey, label: String)? {
+        do {
+            var descriptor = FetchDescriptor<PersistentWatermarkKey>(
+                predicate: #Predicate { $0.id == id }
+            )
+            descriptor.fetchLimit = 1
+            descriptor.includePendingChanges = true
+            guard let saved = try modelContext.fetch(descriptor).first,
+                  let key = saved.watermarkKey else { return nil }
+            saved.lastUsedAt = Date()
+            try saveIfNeeded()
+            return (key, saved.label)
+        } catch {
+            recordError("Failed to load watermark key: \(error.localizedDescription)", error: error)
+            return nil
+        }
+    }
+
+    /// Saved keys are provenance history: deleting one makes every file marked
+    /// with it unverifiable, so this is only for keys created by mistake.
+    func deleteWatermarkKey(id: UUID) {
+        do {
+            var descriptor = FetchDescriptor<PersistentWatermarkKey>(
+                predicate: #Predicate { $0.id == id }
+            )
+            descriptor.fetchLimit = 1
+            if let saved = try modelContext.fetch(descriptor).first {
+                modelContext.delete(saved)
+                try saveIfNeeded()
+            }
+        } catch {
+            recordError("Failed to delete watermark key: \(error.localizedDescription)", error: error)
         }
     }
 

--- a/ObjectCaptureReconstruction/Store/JobStore.swift
+++ b/ObjectCaptureReconstruction/Store/JobStore.swift
@@ -7,6 +7,7 @@ SwiftData persistence layer for saving and loading the job queue and schedule.
 
 import Foundation
 import SwiftData
+import WatermarkCore
 import os
 
 private let logger = Logger(subsystem: ObjectCaptureReconstructionApp.subsystem,
@@ -51,7 +52,8 @@ class JobStore {
         let schema = Schema([
             PersistentJob.self,
             PersistentScheduleSettings.self,
-            PersistentMigrationState.self
+            PersistentMigrationState.self,
+            PersistentExportRecord.self
         ])
         let configuration = ModelConfiguration(
             schema: schema,
@@ -133,6 +135,59 @@ class JobStore {
         } catch {
             recordError("Failed to load jobs: \(error.localizedDescription)", error: error)
             return []
+        }
+    }
+
+    // MARK: - Provenance export records
+
+    /// Export records are append-only provenance history: they are never
+    /// updated in place and intentionally survive job deletion.
+    func saveExportRecords(_ records: [WatermarkRecord]) {
+        guard !records.isEmpty else { return }
+        do {
+            for record in records {
+                modelContext.insert(try PersistentExportRecord(record: record))
+            }
+            try saveIfNeeded()
+            logger.log("Saved \(records.count) provenance export record(s).")
+            lastErrorMessage = nil
+        } catch {
+            recordError("Failed to save export records: \(error.localizedDescription)", error: error)
+        }
+    }
+
+    func exportRecords(jobId: UUID) -> [WatermarkRecord] {
+        do {
+            var descriptor = FetchDescriptor<PersistentExportRecord>(
+                predicate: #Predicate { $0.jobId == jobId },
+                sortBy: [SortDescriptor(\.createdAt)]
+            )
+            descriptor.includePendingChanges = true
+            return try modelContext.fetch(descriptor).compactMap { try? $0.toRecord() }
+        } catch {
+            recordError("Failed to load export records: \(error.localizedDescription)", error: error)
+            return []
+        }
+    }
+
+    /// Most recent record for one exported file, used to make USDZ stamping
+    /// idempotent across job retries.
+    func latestExportRecord(jobId: UUID, detailLevel: String, format: String) -> WatermarkRecord? {
+        do {
+            var descriptor = FetchDescriptor<PersistentExportRecord>(
+                predicate: #Predicate {
+                    $0.jobId == jobId
+                        && $0.detailLevelRawValue == detailLevel
+                        && $0.formatRawValue == format
+                },
+                sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+            )
+            descriptor.fetchLimit = 1
+            descriptor.includePendingChanges = true
+            return try modelContext.fetch(descriptor).first.flatMap { try? $0.toRecord() }
+        } catch {
+            recordError("Failed to load export record: \(error.localizedDescription)", error: error)
+            return nil
         }
     }
 

--- a/ObjectCaptureReconstruction/Watermark/WatermarkingService.swift
+++ b/ObjectCaptureReconstruction/Watermark/WatermarkingService.swift
@@ -16,18 +16,48 @@ import WatermarkCore
 /// Per-file stamping instruction handed to an export converter. Every exported
 /// file gets its own fresh key, so every distributed file maps to exactly one
 /// export record.
-struct WatermarkStamp {
+struct WatermarkStamp: Sendable {
     let key: WatermarkKey
+    /// Label when this stamp reuses a saved library key; nil for a fresh
+    /// per-copy key.
+    var keyLabel: String?
     let geometryParameters: GeometryWatermarkParameters
     let textureParameters: TextureWatermarkParameters
 
-    static func fresh() -> WatermarkStamp {
-        WatermarkStamp(
-            key: .random(),
-            geometryParameters: GeometryWatermarkParameters(),
-            textureParameters: TextureWatermarkParameters()
-        )
+    init(
+        key: WatermarkKey,
+        keyLabel: String? = nil,
+        geometryParameters: GeometryWatermarkParameters = GeometryWatermarkParameters(),
+        textureParameters: TextureWatermarkParameters = TextureWatermarkParameters()
+    ) {
+        self.key = key
+        self.keyLabel = keyLabel
+        self.geometryParameters = geometryParameters
+        self.textureParameters = textureParameters
     }
+
+    /// A brand-new key, unique to this one file — full per-copy traceability.
+    static func fresh() -> WatermarkStamp {
+        WatermarkStamp(key: .random())
+    }
+
+    /// Reuse a saved library key. Every file stamped with it carries the same
+    /// mark, so a leak traces to the label rather than to one copy.
+    static func reusing(_ shared: SharedWatermarkKey) -> WatermarkStamp {
+        WatermarkStamp(key: shared.key, keyLabel: shared.label)
+    }
+
+    /// One file's stamp: the shared key when the job selected one, otherwise
+    /// a fresh key.
+    static func next(sharedKey: SharedWatermarkKey?) -> WatermarkStamp {
+        sharedKey.map(reusing) ?? .fresh()
+    }
+}
+
+/// A saved library key resolved for use by an export run.
+struct SharedWatermarkKey: Sendable {
+    let key: WatermarkKey
+    let label: String
 }
 
 /// What a converter actually embedded (channels can be skipped, e.g. geometry
@@ -79,6 +109,7 @@ enum WatermarkingService {
             filename: fileURL.lastPathComponent,
             filePath: fileURL.path,
             key: stamp.key,
+            keyLabel: stamp.keyLabel,
             channels: channels,
             geometry: outcome.geometry,
             texture: outcome.texture,

--- a/ObjectCaptureReconstruction/Watermark/WatermarkingService.swift
+++ b/ObjectCaptureReconstruction/Watermark/WatermarkingService.swift
@@ -1,0 +1,104 @@
+/*
+See the LICENSE.txt file for this sample's licensing information.
+
+Abstract:
+Glue between the export pipeline and RealityMarkKit: per-file stamping
+instructions, embed outcomes, and export-record assembly. The algorithm is
+public (see docs/ARCHITECTURE.md); all security rests on the per-copy key
+stored in the export record.
+*/
+
+import CryptoKit
+import Foundation
+import ModelFileIO
+import WatermarkCore
+
+/// Per-file stamping instruction handed to an export converter. Every exported
+/// file gets its own fresh key, so every distributed file maps to exactly one
+/// export record.
+struct WatermarkStamp {
+    let key: WatermarkKey
+    let geometryParameters: GeometryWatermarkParameters
+    let textureParameters: TextureWatermarkParameters
+
+    static func fresh() -> WatermarkStamp {
+        WatermarkStamp(
+            key: .random(),
+            geometryParameters: GeometryWatermarkParameters(),
+            textureParameters: TextureWatermarkParameters()
+        )
+    }
+}
+
+/// What a converter actually embedded (channels can be skipped, e.g. geometry
+/// on meshes too small to bin).
+struct WatermarkStampOutcome {
+    var geometry: WatermarkRecord.GeometryChannelInfo?
+    var texture: WatermarkRecord.TextureChannelInfo?
+
+    static let none = WatermarkStampOutcome(geometry: nil, texture: nil)
+
+    var channels: [String] {
+        var channels: [String] = []
+        if geometry != nil { channels.append(WatermarkRecord.Channel.geometry) }
+        if texture != nil { channels.append(WatermarkRecord.Channel.texture) }
+        return channels
+    }
+}
+
+enum WatermarkingService {
+    /// Assemble the persistent record for a stamped export file. Returns nil
+    /// when nothing was embedded (no record should exist for unmarked files).
+    nonisolated static func record(
+        for stamp: WatermarkStamp,
+        outcome: WatermarkStampOutcome,
+        jobId: UUID,
+        detailLevel: CodableDetailLevel,
+        format: String,
+        fileURL: URL
+    ) throws -> WatermarkRecord? {
+        let channels = outcome.channels
+        guard !channels.isEmpty else { return nil }
+        return WatermarkRecord(
+            jobId: jobId,
+            format: format,
+            detailLevel: detailLevel.rawValue,
+            filename: fileURL.lastPathComponent,
+            filePath: fileURL.path,
+            key: stamp.key,
+            channels: channels,
+            geometry: outcome.geometry,
+            texture: outcome.texture,
+            fileSHA256: try sha256Hex(of: fileURL)
+        )
+    }
+
+    nonisolated static func sha256Hex(of url: URL) throws -> String {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Stamp an encoded texture payload: decode → embed → re-encode as PNG.
+    /// Returns nil (leaving the original untouched) if the payload cannot be
+    /// decoded — a failed stamp must never break the export.
+    nonisolated static func stampedTexture(
+        pngData: Data,
+        name: String,
+        stamp: WatermarkStamp
+    ) -> (data: Data, image: WatermarkRecord.TextureChannelInfo.Image)? {
+        guard let image = try? ImageCodec.decode(pngData),
+              let stamped = try? TextureWatermarker.embed(
+                  image: image,
+                  key: stamp.key,
+                  parameters: stamp.textureParameters
+              ),
+              let data = try? ImageCodec.pngData(from: stamped) else { return nil }
+        let info = WatermarkRecord.TextureChannelInfo.Image(
+            name: name,
+            semantic: "baseColor",
+            width: stamped.width,
+            height: stamped.height
+        )
+        return (data, info)
+    }
+}

--- a/ObjectCaptureReconstruction/Watermark/WatermarkingService.swift
+++ b/ObjectCaptureReconstruction/Watermark/WatermarkingService.swift
@@ -46,6 +46,19 @@ struct WatermarkStampOutcome {
     }
 }
 
+enum WatermarkingError: LocalizedError {
+    /// Watermarking was requested but no channel could be embedded — the file
+    /// would be untraceable, so the export must not silently succeed.
+    case nothingEmbedded(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .nothingEmbedded(let filename):
+            return "Provenance watermark could not be embedded in \(filename) (model too small or textures not encodable)."
+        }
+    }
+}
+
 enum WatermarkingService {
     /// Assemble the persistent record for a stamped export file. Returns nil
     /// when nothing was embedded (no record should exist for unmarked files).

--- a/ObjectCaptureReconstructionTests/ExportRecordStoreTests.swift
+++ b/ObjectCaptureReconstructionTests/ExportRecordStoreTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import Object_Capture_Reconstruction
+import WatermarkCore
+
+@MainActor
+final class ExportRecordStoreTests: XCTestCase {
+
+    private func makeRecord(
+        jobId: UUID,
+        format: String = "glb",
+        detailLevel: String = "medium",
+        createdAt: Date = Date(timeIntervalSince1970: 1_752_000_000),
+        sha: String = String(repeating: "ab", count: 32)
+    ) -> WatermarkRecord {
+        WatermarkRecord(
+            jobId: jobId,
+            format: format,
+            detailLevel: detailLevel,
+            filename: "model-\(detailLevel).\(format)",
+            filePath: "/tmp/model-\(detailLevel).\(format)",
+            createdAt: createdAt,
+            key: .random(),
+            channels: [WatermarkRecord.Channel.geometry],
+            geometry: .init(parameters: GeometryWatermarkParameters(), effectiveBinCount: 64, embeddedBits: 60),
+            texture: nil,
+            fileSHA256: sha
+        )
+    }
+
+    func testRecordsRoundTripThroughStore() throws {
+        let store = try JobStore(inMemory: true)
+        let jobId = UUID()
+        let record = makeRecord(jobId: jobId)
+
+        store.saveExportRecords([record])
+        let loaded = store.exportRecords(jobId: jobId)
+
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded.first?.recordId, record.recordId)
+        XCTAssertEqual(loaded.first?.key, record.key)
+        XCTAssertEqual(loaded.first?.channels, record.channels)
+        XCTAssertEqual(loaded.first?.geometry, record.geometry)
+        XCTAssertEqual(loaded.first?.fileSHA256, record.fileSHA256)
+        XCTAssertEqual(loaded.first?.format, "glb")
+    }
+
+    func testLatestRecordPicksNewestForFileSlot() throws {
+        let store = try JobStore(inMemory: true)
+        let jobId = UUID()
+        let older = makeRecord(jobId: jobId, createdAt: Date(timeIntervalSince1970: 1_000), sha: "old")
+        let newer = makeRecord(jobId: jobId, createdAt: Date(timeIntervalSince1970: 2_000), sha: "new")
+        let otherLevel = makeRecord(jobId: jobId, detailLevel: "full", createdAt: Date(timeIntervalSince1970: 3_000))
+
+        store.saveExportRecords([older, newer, otherLevel])
+
+        let latest = store.latestExportRecord(jobId: jobId, detailLevel: "medium", format: "glb")
+        XCTAssertEqual(latest?.recordId, newer.recordId)
+        XCTAssertNil(store.latestExportRecord(jobId: jobId, detailLevel: "medium", format: "ply"))
+    }
+
+    func testRecordsSurviveJobDeletion() throws {
+        let store = try JobStore(inMemory: true)
+        let job = ReconstructionJob(
+            imageFolder: URL(fileURLWithPath: "/tmp/images"),
+            modelFolder: URL(fileURLWithPath: "/tmp/models"),
+            modelName: "Chair"
+        )
+        store.saveJob(job)
+        store.saveExportRecords([makeRecord(jobId: job.id)])
+
+        store.deleteJob(id: job.id)
+
+        XCTAssertTrue(store.loadJobs().isEmpty)
+        XCTAssertEqual(store.exportRecords(jobId: job.id).count, 1,
+                       "provenance records must outlive the job")
+    }
+
+    func testWatermarkFlagPersistsThroughStore() throws {
+        let store = try JobStore(inMemory: true)
+        var job = ReconstructionJob(
+            imageFolder: URL(fileURLWithPath: "/tmp/images"),
+            modelFolder: URL(fileURLWithPath: "/tmp/models"),
+            modelName: "Lamp"
+        )
+        job.watermarkEnabled = true
+        store.saveJob(job)
+
+        let reloaded = store.loadJobs().first
+        XCTAssertEqual(reloaded?.isWatermarkEnabled, true)
+    }
+}

--- a/ObjectCaptureReconstructionTests/ExportRecordStoreTests.swift
+++ b/ObjectCaptureReconstructionTests/ExportRecordStoreTests.swift
@@ -75,6 +75,80 @@ final class ExportRecordStoreTests: XCTestCase {
                        "provenance records must outlive the job")
     }
 
+    // MARK: - Key library
+
+    func testCreatedKeysAreListedAndResolvable() throws {
+        let store = try JobStore(inMemory: true)
+
+        let created = try XCTUnwrap(store.createWatermarkKey(label: "Client A"))
+        XCTAssertEqual(created.label, "Client A")
+
+        XCTAssertEqual(store.watermarkKeys().map(\.label), ["Client A"])
+
+        let resolved = try XCTUnwrap(store.watermarkKey(id: created.id))
+        XCTAssertEqual(resolved.label, "Client A")
+        XCTAssertEqual(resolved.key.data.count, WatermarkKey.byteCount)
+
+        // Resolving marks the key as used.
+        XCTAssertNotNil(store.watermarkKeys().first?.lastUsedAt)
+    }
+
+    func testKeyLabelsAreUniqueAndTrimmedAndNonEmpty() throws {
+        let store = try JobStore(inMemory: true)
+
+        XCTAssertNotNil(store.createWatermarkKey(label: "Portfolio"))
+        XCTAssertNil(store.createWatermarkKey(label: "Portfolio"), "duplicate labels must be rejected")
+        XCTAssertNil(store.createWatermarkKey(label: "  Portfolio  "), "labels are compared trimmed")
+        XCTAssertNil(store.createWatermarkKey(label: "   "), "blank labels must be rejected")
+        XCTAssertEqual(store.watermarkKeys().count, 1)
+    }
+
+    func testDistinctKeysHaveDistinctMaterial() throws {
+        let store = try JobStore(inMemory: true)
+        let first = try XCTUnwrap(store.createWatermarkKey(label: "One"))
+        let second = try XCTUnwrap(store.createWatermarkKey(label: "Two"))
+
+        let firstKey = try XCTUnwrap(store.watermarkKey(id: first.id)).key
+        let secondKey = try XCTUnwrap(store.watermarkKey(id: second.id)).key
+        XCTAssertNotEqual(firstKey, secondKey)
+    }
+
+    func testMissingKeyResolvesToNil() throws {
+        let store = try JobStore(inMemory: true)
+        XCTAssertNil(store.watermarkKey(id: UUID()))
+    }
+
+    func testSelectedKeyPersistsWithJob() throws {
+        let store = try JobStore(inMemory: true)
+        let created = try XCTUnwrap(store.createWatermarkKey(label: "Client B"))
+
+        var job = ReconstructionJob(
+            imageFolder: URL(fileURLWithPath: "/tmp/images"),
+            modelFolder: URL(fileURLWithPath: "/tmp/models"),
+            modelName: "Statue"
+        )
+        job.watermarkEnabled = true
+        job.watermarkKeyId = created.id
+        store.saveJob(job)
+
+        XCTAssertEqual(store.loadJobs().first?.watermarkKeyId, created.id)
+    }
+
+    func testKeyLabelRoundTripsThroughRecord() throws {
+        let store = try JobStore(inMemory: true)
+        let jobId = UUID()
+        var record = makeRecord(jobId: jobId)
+        record.keyLabel = "Client A"
+
+        store.saveExportRecords([record])
+        XCTAssertEqual(store.exportRecords(jobId: jobId).first?.keyLabel, "Client A")
+
+        // Per-copy keys stay unlabeled.
+        let otherJobId = UUID()
+        store.saveExportRecords([makeRecord(jobId: otherJobId)])
+        XCTAssertNil(store.exportRecords(jobId: otherJobId).first?.keyLabel)
+    }
+
     func testWatermarkFlagPersistsThroughStore() throws {
         let store = try JobStore(inMemory: true)
         var job = ReconstructionJob(

--- a/ObjectCaptureReconstructionTests/USDZStamperTests.swift
+++ b/ObjectCaptureReconstructionTests/USDZStamperTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Object_Capture_Reconstruction
+import CoreGraphics
+import ModelFileIO
+import WatermarkCore
+
+@MainActor
+final class USDZStamperTests: XCTestCase {
+
+    /// Synthetic photo-like texture PNG.
+    private func makeTexturePNG(width: Int, height: Int) throws -> Data {
+        var pixels = [UInt8](repeating: 255, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                let offset = (y * width + x) * 4
+                let value = 90.0 + 80.0 * Double(x) / Double(width)
+                    + 40.0 * sin(Double(x) * 0.11) * cos(Double(y) * 0.07)
+                pixels[offset] = UInt8(min(255, max(0, value)))
+                pixels[offset + 1] = UInt8(min(255, max(0, value * 0.8)))
+                pixels[offset + 2] = UInt8(min(255, max(0, value * 0.6)))
+            }
+        }
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        let image = pixels.withUnsafeMutableBytes { buffer in
+            CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )!.makeImage()!
+        }
+        return try ImageCodec.pngData(from: image)
+    }
+
+    /// usdz-shaped fixture: a fake `.usdc` payload plus base-color and normal
+    /// PNG entries. ModelIO can't parse the fake usdc, so the stamper falls
+    /// back to the filename heuristic — which is the fragile path worth testing.
+    private func makeFixtureUSDZ(in directory: URL) throws -> (url: URL, usdcBytes: Data, normalBytes: Data) {
+        let usdcBytes = Data((0..<50_000).map { UInt8(truncatingIfNeeded: $0 &* 13) })
+        let texturePNG = try makeTexturePNG(width: 256, height: 256)
+        let normalPNG = try makeTexturePNG(width: 64, height: 64)
+
+        let archive = UsdzArchive(entries: [
+            .init(name: "model.usdc", data: usdcBytes),
+            .init(name: "0/baked_mesh_tex0.png", data: texturePNG),
+            .init(name: "0/baked_mesh_norm0.png", data: normalPNG),
+        ])
+        let url = directory.appending(path: "fixture.usdz")
+        try archive.write(to: url)
+        return (url, usdcBytes, normalPNG)
+    }
+
+    func testStampMarksBaseColorOnlyAndPreservesUSDC() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let (usdzURL, usdcBytes, normalBytes) = try makeFixtureUSDZ(in: directory)
+
+        let stamp = WatermarkStamp(
+            key: try WatermarkKey(data: Data(repeating: 0x2A, count: WatermarkKey.byteCount)),
+            geometryParameters: GeometryWatermarkParameters(),
+            textureParameters: TextureWatermarkParameters()
+        )
+        let result = try USDZStamper.stampTextures(usdzURL: usdzURL, stamp: stamp)
+
+        XCTAssertEqual(result.stampedImages.count, 1)
+        XCTAssertEqual(result.stampedImages.first?.name, "0/baked_mesh_tex0.png")
+        XCTAssertEqual(try WatermarkingService.sha256Hex(of: usdzURL), result.fileSHA256)
+
+        let reread = try UsdzArchive.read(url: usdzURL)
+        XCTAssertEqual(reread.entries[0].data, usdcBytes, ".usdc bytes must be untouched")
+        XCTAssertEqual(reread.entries[2].data, normalBytes, "normal map must be untouched")
+
+        let stampedImage = try ImageCodec.decode(reread.entries[1].data)
+        let detection = TextureWatermarker.detect(
+            image: stampedImage,
+            key: stamp.key,
+            parameters: stamp.textureParameters
+        )
+        XCTAssertLessThan(detection.pValue, 1e-6)
+
+        let wrongDetection = TextureWatermarker.detect(
+            image: stampedImage,
+            key: try WatermarkKey(data: Data(repeating: 0x2B, count: WatermarkKey.byteCount)),
+            parameters: stamp.textureParameters
+        )
+        XCTAssertGreaterThan(wrongDetection.pValue, 1e-3)
+    }
+
+    func testStampFailureLeavesOriginalUntouched() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        // Archive with no image entries at all.
+        let archive = UsdzArchive(entries: [
+            .init(name: "model.usdc", data: Data(repeating: 0x55, count: 1024)),
+        ])
+        let url = directory.appending(path: "empty.usdz")
+        try archive.write(to: url)
+        let originalBytes = try Data(contentsOf: url)
+
+        XCTAssertThrowsError(try USDZStamper.stampTextures(usdzURL: url, stamp: .fresh()))
+        XCTAssertEqual(try Data(contentsOf: url), originalBytes)
+    }
+}

--- a/ObjectCaptureReconstructionTests/USDZStamperTests.swift
+++ b/ObjectCaptureReconstructionTests/USDZStamperTests.swift
@@ -89,6 +89,35 @@ final class USDZStamperTests: XCTestCase {
         XCTAssertGreaterThan(wrongDetection.pValue, 1e-3)
     }
 
+    func testStageLeavesOriginalUntouchedUntilCommit() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let (usdzURL, _, _) = try makeFixtureUSDZ(in: directory)
+        let originalBytes = try Data(contentsOf: usdzURL)
+
+        let stamp = WatermarkStamp(
+            key: try WatermarkKey(data: Data(repeating: 0x2C, count: WatermarkKey.byteCount)),
+            geometryParameters: GeometryWatermarkParameters(),
+            textureParameters: TextureWatermarkParameters()
+        )
+
+        // Stage: original untouched, staged copy has the promised hash.
+        let staged = try USDZStamper.stage(usdzURL: usdzURL, stamp: stamp)
+        XCTAssertEqual(try Data(contentsOf: usdzURL), originalBytes)
+        XCTAssertEqual(try WatermarkingService.sha256Hex(of: staged.temporaryURL), staged.fileSHA256)
+
+        // Discard: original still untouched, temp gone.
+        USDZStamper.discard(staged)
+        XCTAssertEqual(try Data(contentsOf: usdzURL), originalBytes)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: staged.temporaryURL.path))
+
+        // Stage + commit: destination now carries the staged bytes.
+        let secondStaged = try USDZStamper.stage(usdzURL: usdzURL, stamp: stamp)
+        try USDZStamper.commit(secondStaged, to: usdzURL)
+        XCTAssertEqual(try WatermarkingService.sha256Hex(of: usdzURL), secondStaged.fileSHA256)
+        XCTAssertNotEqual(try Data(contentsOf: usdzURL), originalBytes)
+    }
+
     func testStampFailureLeavesOriginalUntouched() throws {
         let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/ObjectCaptureReconstructionTests/WatermarkExportTests.swift
+++ b/ObjectCaptureReconstructionTests/WatermarkExportTests.swift
@@ -94,6 +94,61 @@ final class WatermarkExportTests: XCTestCase {
         XCTAssertGreaterThan(wrongDetection.pValue, 1e-3)
     }
 
+    // MARK: - Key reuse
+
+    func testSharedKeyMarksEveryFileWithTheSameKey() {
+        let shared = SharedWatermarkKey(key: .random(), label: "Client A")
+
+        let first = WatermarkStamp.next(sharedKey: shared)
+        let second = WatermarkStamp.next(sharedKey: shared)
+        XCTAssertEqual(first.key, second.key)
+        XCTAssertEqual(first.key, shared.key)
+        XCTAssertEqual(first.keyLabel, "Client A")
+
+        // The default stays per-copy: every file gets unique, unlabeled keys.
+        let fresh = WatermarkStamp.next(sharedKey: nil)
+        let anotherFresh = WatermarkStamp.next(sharedKey: nil)
+        XCTAssertNotEqual(fresh.key, anotherFresh.key)
+        XCTAssertNil(fresh.keyLabel)
+    }
+
+    func testOneSharedKeyVerifiesAcrossDifferentExportedFormats() throws {
+        let directory = try makeTemporaryDirectory()
+        let sourceURL = directory.appending(path: "box.usdc")
+        let glbURL = directory.appending(path: "box.glb")
+        let plyURL = directory.appending(path: "box.ply")
+        try writeSampleUSD(to: sourceURL)
+
+        // The same saved key stamps two different exports of the same model.
+        let shared = SharedWatermarkKey(
+            key: try WatermarkKey(data: Data(repeating: 0x3A, count: WatermarkKey.byteCount)),
+            label: "Client A"
+        )
+        let glbOutcome = try USDZToGLTFConverter.convert(
+            usdzURL: sourceURL, format: .glb, outputURL: glbURL,
+            watermark: .next(sharedKey: shared)
+        )
+        let plyOutcome = try SplatSampleGenerator.generate(
+            usdzURL: sourceURL, outputURL: plyURL, targetCount: 30_000,
+            watermark: .next(sharedKey: shared)
+        )
+
+        // Both files verify under that one key.
+        let glbDetection = GeometryWatermarker.detect(
+            positions: try MiniGLTFReader.read(url: glbURL).positions,
+            key: shared.key,
+            parameters: try XCTUnwrap(glbOutcome.geometry).detectionParameters
+        )
+        XCTAssertLessThan(glbDetection.pValue, 1e-6)
+
+        let plyDetection = GeometryWatermarker.detect(
+            positions: try PLYReader.readPositions(url: plyURL),
+            key: shared.key,
+            parameters: try XCTUnwrap(plyOutcome.geometry).detectionParameters
+        )
+        XCTAssertLessThan(plyDetection.pValue, 1e-6)
+    }
+
     func testUnwatermarkedConvertLeavesNoOutcome() throws {
         let directory = try makeTemporaryDirectory()
         let sourceURL = directory.appending(path: "box.usdc")

--- a/ObjectCaptureReconstructionTests/WatermarkExportTests.swift
+++ b/ObjectCaptureReconstructionTests/WatermarkExportTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Object_Capture_Reconstruction
+import ModelFileIO
+import ModelIO
+import WatermarkCore
+import simd
+
+/// End-to-end checks that the export pipeline embeds a detectable, keyed
+/// provenance watermark in GLB and splat-PLY outputs, and that wrong keys
+/// detect at chance level.
+@MainActor
+final class WatermarkExportTests: XCTestCase {
+
+    /// Fixed keys keep the test fully deterministic: which bits land in which
+    /// bins (and therefore the exact detection statistic) depends on the key.
+    private func fixedStamp(byte: UInt8 = 0x2A) throws -> WatermarkStamp {
+        WatermarkStamp(
+            key: try WatermarkKey(data: Data(repeating: byte, count: WatermarkKey.byteCount)),
+            geometryParameters: GeometryWatermarkParameters(),
+            textureParameters: TextureWatermarkParameters()
+        )
+    }
+
+    private func wrongKey() throws -> WatermarkKey {
+        try WatermarkKey(data: Data(repeating: 0x2B, count: WatermarkKey.byteCount))
+    }
+
+    func testGLBExportEmbedsDetectableGeometryWatermark() throws {
+        let directory = try makeTemporaryDirectory()
+        let sourceURL = directory.appending(path: "box.usdc")
+        let glbURL = directory.appending(path: "box.glb")
+        try writeSampleUSD(to: sourceURL)
+
+        let stamp = try fixedStamp()
+        let outcome = try USDZToGLTFConverter.convert(
+            usdzURL: sourceURL,
+            format: .glb,
+            outputURL: glbURL,
+            watermark: stamp
+        )
+
+        let geometry = try XCTUnwrap(outcome.geometry, "fixture should have enough vertices to embed")
+        XCTAssertGreaterThan(geometry.embeddedBits, 0)
+
+        let asset = try MiniGLTFReader.read(url: glbURL)
+        XCTAssertGreaterThanOrEqual(asset.positions.count, 2048)
+
+        let detection = GeometryWatermarker.detect(
+            positions: asset.positions,
+            key: stamp.key,
+            parameters: geometry.detectionParameters
+        )
+        XCTAssertEqual(detection.matchedBits, detection.totalBits)
+        XCTAssertLessThan(detection.pValue, 1e-6)
+
+        let wrongDetection = GeometryWatermarker.detect(
+            positions: asset.positions,
+            key: try wrongKey(),
+            parameters: geometry.detectionParameters
+        )
+        XCTAssertGreaterThan(wrongDetection.pValue, 1e-3)
+    }
+
+    func testSplatExportEmbedsDetectableGeometryWatermark() throws {
+        let directory = try makeTemporaryDirectory()
+        let sourceURL = directory.appending(path: "box.usdc")
+        let plyURL = directory.appending(path: "box.ply")
+        try writeSampleUSD(to: sourceURL)
+
+        let stamp = try fixedStamp()
+        let outcome = try SplatSampleGenerator.generate(
+            usdzURL: sourceURL,
+            outputURL: plyURL,
+            targetCount: 30_000,
+            watermark: stamp
+        )
+
+        let geometry = try XCTUnwrap(outcome.geometry)
+        let positions = try PLYReader.readPositions(url: plyURL)
+        XCTAssertGreaterThanOrEqual(positions.count, 30_000)
+
+        let detection = GeometryWatermarker.detect(
+            positions: positions,
+            key: stamp.key,
+            parameters: geometry.detectionParameters
+        )
+        XCTAssertLessThan(detection.pValue, 1e-6)
+
+        let wrongDetection = GeometryWatermarker.detect(
+            positions: positions,
+            key: try wrongKey(),
+            parameters: geometry.detectionParameters
+        )
+        XCTAssertGreaterThan(wrongDetection.pValue, 1e-3)
+    }
+
+    func testUnwatermarkedConvertLeavesNoOutcome() throws {
+        let directory = try makeTemporaryDirectory()
+        let sourceURL = directory.appending(path: "box.usdc")
+        let glbURL = directory.appending(path: "box.glb")
+        try writeSampleUSD(to: sourceURL)
+
+        let outcome = try USDZToGLTFConverter.convert(
+            usdzURL: sourceURL,
+            format: .glb,
+            outputURL: glbURL
+        )
+        XCTAssertNil(outcome.geometry)
+        XCTAssertNil(outcome.texture)
+        XCTAssertTrue(outcome.channels.isEmpty)
+    }
+
+    // MARK: - Fixtures
+
+    /// Densely segmented box: broad radial-norm distribution (unlike a sphere)
+    /// and enough vertices for the binned geometry watermark.
+    private func writeSampleUSD(to url: URL) throws {
+        let allocator = MDLMeshBufferDataAllocator()
+        let mesh = MDLMesh(
+            boxWithExtent: SIMD3<Float>(0.2, 0.2, 0.2),
+            segments: SIMD3<UInt32>(28, 28, 28),
+            inwardNormals: false,
+            geometryType: .triangles,
+            allocator: allocator
+        )
+
+        let asset = MDLAsset()
+        asset.add(mesh)
+        try asset.export(to: url)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Apple Object Capture is powerful, but running one folder at a time is tedious wh
 - **Interrupted-job recovery**: running jobs are restored as interrupted on launch and can be retried.
 - **Retry-safe exports**: completed outputs are skipped on retry, while stale partial files are replaced before reconstruction resumes.
 - **Sandbox-friendly folder access**: user-selected input and output folders are restored with security-scoped bookmarks.
-- **Provenance watermarking (opt-in)**: imperceptibly stamp every exported file with a per-copy secret key so leaked copies can be traced to the export that produced them — public algorithm, private keys (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#provenance-watermarking)).
+- **Provenance watermarking (opt-in)**: imperceptibly stamp every exported file with a secret key so leaked copies can be traced back — a fresh per-copy key by default, or a saved labeled key reused across jobs as an ownership stamp. Public algorithm, private keys (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#provenance-watermarking)).
 - **Progress and notifications**: track job progress, estimated time remaining, failures, and queue completion.
 
 ## Screens And Workflow

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Apple Object Capture is powerful, but running one folder at a time is tedious wh
 - **Interrupted-job recovery**: running jobs are restored as interrupted on launch and can be retried.
 - **Retry-safe exports**: completed outputs are skipped on retry, while stale partial files are replaced before reconstruction resumes.
 - **Sandbox-friendly folder access**: user-selected input and output folders are restored with security-scoped bookmarks.
+- **Provenance watermarking (opt-in)**: imperceptibly stamp every exported file with a per-copy secret key so leaked copies can be traced to the export that produced them — public algorithm, private keys (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md#provenance-watermarking)).
 - **Progress and notifications**: track job progress, estimated time remaining, failures, and queue completion.
 
 ## Screens And Workflow

--- a/RealityMarkKit/Package.swift
+++ b/RealityMarkKit/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "RealityMarkKit",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "WatermarkCore", targets: ["WatermarkCore"]),
+        .library(name: "ModelFileIO", targets: ["ModelFileIO"]),
+        .executable(name: "watermark-verify", targets: ["watermark-verify"]),
+    ],
+    targets: [
+        .target(name: "WatermarkCore"),
+        .target(name: "ModelFileIO"),
+        .executableTarget(
+            name: "watermark-verify",
+            dependencies: ["WatermarkCore", "ModelFileIO"]
+        ),
+        .testTarget(name: "WatermarkCoreTests", dependencies: ["WatermarkCore"]),
+        .testTarget(name: "ModelFileIOTests", dependencies: ["ModelFileIO", "WatermarkCore"]),
+    ]
+)

--- a/RealityMarkKit/Sources/ModelFileIO/ImageCodec.swift
+++ b/RealityMarkKit/Sources/ModelFileIO/ImageCodec.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+public enum ImageCodecError: Error {
+    case decodeFailed
+    case encodeFailed
+}
+
+/// CGImage ⇄ PNG/JPEG via ImageIO.
+public enum ImageCodec {
+    public static func decode(_ data: Data) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ImageCodecError.decodeFailed
+        }
+        return image
+    }
+
+    public static func pngData(from image: CGImage) throws -> Data {
+        try encode(image, type: UTType.png, options: nil)
+    }
+
+    public static func jpegData(from image: CGImage, quality: Double) throws -> Data {
+        let options = [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+        return try encode(image, type: UTType.jpeg, options: options)
+    }
+
+    /// Detects PNG vs JPEG payloads by magic bytes; nil for anything else.
+    public static func imageFormat(of data: Data) -> ImageFormat? {
+        if data.starts(with: [0x89, 0x50, 0x4E, 0x47]) { return .png }
+        if data.starts(with: [0xFF, 0xD8, 0xFF]) { return .jpeg }
+        return nil
+    }
+
+    public enum ImageFormat {
+        case png
+        case jpeg
+    }
+
+    private static func encode(_ image: CGImage, type: UTType, options: CFDictionary?) throws -> Data {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData, type.identifier as CFString, 1, nil
+        ) else {
+            throw ImageCodecError.encodeFailed
+        }
+        CGImageDestinationAddImage(destination, image, options)
+        guard CGImageDestinationFinalize(destination) else {
+            throw ImageCodecError.encodeFailed
+        }
+        return data as Data
+    }
+}

--- a/RealityMarkKit/Sources/ModelFileIO/MiniGLTFReader.swift
+++ b/RealityMarkKit/Sources/ModelFileIO/MiniGLTFReader.swift
@@ -1,0 +1,229 @@
+import Foundation
+import simd
+
+public enum MiniGLTFError: Error {
+    case invalidGLBHeader
+    case missingJSONChunk
+    case missingBuffer(Int)
+    case unsupportedAccessor(String)
+}
+
+public struct MiniGLTFAsset {
+    /// Concatenated contents of every unique POSITION accessor, in document order.
+    public var positions: [SIMD3<Float>]
+    /// Encoded payloads (PNG/JPEG bytes) of images referenced as base-color textures.
+    public var baseColorImages: [Data]
+}
+
+/// Minimal read-only GLB/glTF parser: extracts vertex positions and base-color
+/// images — exactly what watermark detection needs, nothing else. Mirrors the
+/// subset of the glTF 2.0 schema that Reality Pulse's exporter emits, but stays
+/// tolerant of foreign files (re-saved or edited copies).
+public enum MiniGLTFReader {
+    public static func read(url: URL) throws -> MiniGLTFAsset {
+        let data = try Data(contentsOf: url)
+        if data.starts(with: [0x67, 0x6C, 0x54, 0x46]) {  // "glTF"
+            let (json, binary) = try parseGLBChunks(data)
+            return try parse(json: json, embeddedBinary: binary, baseURL: url.deletingLastPathComponent())
+        }
+        return try parse(json: data, embeddedBinary: nil, baseURL: url.deletingLastPathComponent())
+    }
+
+    // MARK: - GLB container
+
+    static func parseGLBChunks(_ data: Data) throws -> (json: Data, binary: Data?) {
+        guard data.count >= 12 else { throw MiniGLTFError.invalidGLBHeader }
+
+        var offset = 12  // magic + version + length
+        var json: Data?
+        var binary: Data?
+        while offset + 8 <= data.count {
+            let chunkLength = Int(readUInt32(data, at: offset))
+            let chunkType = readUInt32(data, at: offset + 4)
+            let start = offset + 8
+            guard start + chunkLength <= data.count else { break }
+            let chunk = data.subdata(in: start..<(start + chunkLength))
+            if chunkType == 0x4E4F_534A {  // "JSON"
+                json = chunk
+            } else if chunkType == 0x004E_4942 {  // "BIN\0"
+                binary = chunk
+            }
+            offset = start + chunkLength
+        }
+
+        guard let json else { throw MiniGLTFError.missingJSONChunk }
+        return (json, binary)
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        var value: UInt32 = 0
+        withUnsafeMutableBytes(of: &value) { destination in
+            data.copyBytes(to: destination, from: offset..<(offset + 4))
+        }
+        return UInt32(littleEndian: value)
+    }
+
+    // MARK: - Document
+
+    private struct Document: Decodable {
+        struct Accessor: Decodable {
+            var bufferView: Int?
+            var byteOffset: Int?
+            var componentType: Int
+            var count: Int
+            var type: String
+        }
+        struct BufferView: Decodable {
+            var buffer: Int
+            var byteOffset: Int?
+            var byteLength: Int
+            var byteStride: Int?
+        }
+        struct Buffer: Decodable {
+            var byteLength: Int
+            var uri: String?
+        }
+        struct Mesh: Decodable {
+            struct Primitive: Decodable {
+                var attributes: [String: Int]
+                var material: Int?
+            }
+            var primitives: [Primitive]
+        }
+        struct Material: Decodable {
+            struct PBR: Decodable {
+                struct TextureRef: Decodable { var index: Int }
+                var baseColorTexture: TextureRef?
+            }
+            var pbrMetallicRoughness: PBR?
+        }
+        struct Texture: Decodable { var source: Int? }
+        struct Image: Decodable {
+            var uri: String?
+            var bufferView: Int?
+        }
+
+        var accessors: [Accessor]?
+        var bufferViews: [BufferView]?
+        var buffers: [Buffer]?
+        var meshes: [Mesh]?
+        var materials: [Material]?
+        var textures: [Texture]?
+        var images: [Image]?
+    }
+
+    private static func parse(json: Data, embeddedBinary: Data?, baseURL: URL) throws -> MiniGLTFAsset {
+        let document = try JSONDecoder().decode(Document.self, from: json)
+
+        var bufferCache: [Int: Data] = [:]
+        func bufferData(_ index: Int) throws -> Data {
+            if let cached = bufferCache[index] { return cached }
+            guard let buffers = document.buffers, buffers.indices.contains(index) else {
+                throw MiniGLTFError.missingBuffer(index)
+            }
+            let data: Data
+            if let uri = buffers[index].uri {
+                data = try resolveURI(uri, baseURL: baseURL)
+            } else if let embeddedBinary {
+                data = embeddedBinary
+            } else {
+                throw MiniGLTFError.missingBuffer(index)
+            }
+            bufferCache[index] = data
+            return data
+        }
+
+        func bufferViewData(_ index: Int) throws -> (data: Data, stride: Int?) {
+            guard let views = document.bufferViews, views.indices.contains(index) else {
+                throw MiniGLTFError.missingBuffer(index)
+            }
+            let view = views[index]
+            let buffer = try bufferData(view.buffer)
+            let start = view.byteOffset ?? 0
+            guard start + view.byteLength <= buffer.count else {
+                throw MiniGLTFError.missingBuffer(index)
+            }
+            return (buffer.subdata(in: start..<(start + view.byteLength)), view.byteStride)
+        }
+
+        // Unique POSITION accessors in first-reference order.
+        var positionAccessors: [Int] = []
+        var seen = Set<Int>()
+        for mesh in document.meshes ?? [] {
+            for primitive in mesh.primitives {
+                if let accessor = primitive.attributes["POSITION"], seen.insert(accessor).inserted {
+                    positionAccessors.append(accessor)
+                }
+            }
+        }
+
+        var positions: [SIMD3<Float>] = []
+        for accessorIndex in positionAccessors {
+            guard let accessors = document.accessors, accessors.indices.contains(accessorIndex) else { continue }
+            let accessor = accessors[accessorIndex]
+            guard accessor.componentType == 5126, accessor.type == "VEC3" else {
+                throw MiniGLTFError.unsupportedAccessor("POSITION accessor must be float VEC3")
+            }
+            guard let viewIndex = accessor.bufferView else { continue }
+            let (viewData, viewStride) = try bufferViewData(viewIndex)
+            let stride = viewStride ?? 12
+            let start = accessor.byteOffset ?? 0
+            positions.reserveCapacity(positions.count + accessor.count)
+            for element in 0..<accessor.count {
+                let offset = start + element * stride
+                guard offset + 12 <= viewData.count else { break }
+                positions.append(SIMD3<Float>(
+                    readFloat(viewData, at: offset),
+                    readFloat(viewData, at: offset + 4),
+                    readFloat(viewData, at: offset + 8)
+                ))
+            }
+        }
+
+        // Base-color images via material → texture → image.
+        var imageIndices: [Int] = []
+        var seenImages = Set<Int>()
+        for material in document.materials ?? [] {
+            guard let textureIndex = material.pbrMetallicRoughness?.baseColorTexture?.index,
+                  let textures = document.textures, textures.indices.contains(textureIndex),
+                  let imageIndex = textures[textureIndex].source,
+                  seenImages.insert(imageIndex).inserted else { continue }
+            imageIndices.append(imageIndex)
+        }
+
+        var baseColorImages: [Data] = []
+        for imageIndex in imageIndices {
+            guard let images = document.images, images.indices.contains(imageIndex) else { continue }
+            let image = images[imageIndex]
+            if let viewIndex = image.bufferView {
+                if let (data, _) = try? bufferViewData(viewIndex) {
+                    baseColorImages.append(data)
+                }
+            } else if let uri = image.uri, let data = try? resolveURI(uri, baseURL: baseURL) {
+                baseColorImages.append(data)
+            }
+        }
+
+        return MiniGLTFAsset(positions: positions, baseColorImages: baseColorImages)
+    }
+
+    private static func readFloat(_ data: Data, at offset: Int) -> Float {
+        var bits: UInt32 = 0
+        withUnsafeMutableBytes(of: &bits) { destination in
+            data.copyBytes(to: destination, from: offset..<(offset + 4))
+        }
+        return Float(bitPattern: UInt32(littleEndian: bits))
+    }
+
+    private static func resolveURI(_ uri: String, baseURL: URL) throws -> Data {
+        if uri.hasPrefix("data:") {
+            guard let comma = uri.firstIndex(of: ","),
+                  let data = Data(base64Encoded: String(uri[uri.index(after: comma)...])) else {
+                throw MiniGLTFError.missingBuffer(-1)
+            }
+            return data
+        }
+        let decoded = uri.removingPercentEncoding ?? uri
+        return try Data(contentsOf: baseURL.appending(path: decoded))
+    }
+}

--- a/RealityMarkKit/Sources/ModelFileIO/ModelFileIO.swift
+++ b/RealityMarkKit/Sources/ModelFileIO/ModelFileIO.swift
@@ -1,0 +1,3 @@
+// ModelFileIO: minimal read/write support for the model container formats the
+// watermark pipeline touches (usdz archives, GLB/glTF, PLY, image codecs).
+// Populated across the provenance-watermark feature phases.

--- a/RealityMarkKit/Sources/ModelFileIO/PLYReader.swift
+++ b/RealityMarkKit/Sources/ModelFileIO/PLYReader.swift
@@ -1,0 +1,109 @@
+import Foundation
+import simd
+
+public enum PLYReaderError: Error {
+    case invalidHeader
+    case unsupportedFormat(String)
+    case missingPositions
+    case truncatedPayload
+}
+
+/// Generic binary little-endian PLY vertex reader — extracts x/y/z positions
+/// from any property layout (superset of the 17-float layout Reality Pulse's
+/// splat writer emits).
+public enum PLYReader {
+    public static func readPositions(url: URL) throws -> [SIMD3<Float>] {
+        try readPositions(data: Data(contentsOf: url))
+    }
+
+    public static func readPositions(data: Data) throws -> [SIMD3<Float>] {
+        guard let headerEndRange = data.range(of: Data("end_header\n".utf8)) else {
+            throw PLYReaderError.invalidHeader
+        }
+        guard let header = String(data: data.subdata(in: 0..<headerEndRange.upperBound), encoding: .ascii),
+              header.hasPrefix("ply") else {
+            throw PLYReaderError.invalidHeader
+        }
+
+        var vertexCount = 0
+        var inVertexElement = false
+        var offset = 0
+        var stride = 0
+        var xOffset: Int?
+        var yOffset: Int?
+        var zOffset: Int?
+
+        for line in header.split(separator: "\n") {
+            let fields = line.split(separator: " ")
+            guard let keyword = fields.first else { continue }
+            switch keyword {
+            case "format":
+                guard fields.count >= 2, fields[1] == "binary_little_endian" else {
+                    throw PLYReaderError.unsupportedFormat(String(line))
+                }
+            case "element":
+                if fields.count >= 3, fields[1] == "vertex" {
+                    inVertexElement = true
+                    vertexCount = Int(fields[2]) ?? 0
+                } else {
+                    inVertexElement = false
+                }
+            case "property":
+                guard inVertexElement, fields.count >= 3 else { continue }
+                guard fields[1] != "list" else {
+                    throw PLYReaderError.unsupportedFormat("list property in vertex element")
+                }
+                let size = try propertySize(String(fields[1]))
+                let name = fields[2]
+                if fields[1] == "float" || fields[1] == "float32" {
+                    if name == "x" { xOffset = offset }
+                    if name == "y" { yOffset = offset }
+                    if name == "z" { zOffset = offset }
+                }
+                offset += size
+                stride = offset
+            default:
+                continue
+            }
+        }
+
+        guard let xOffset, let yOffset, let zOffset, vertexCount > 0, stride > 0 else {
+            throw PLYReaderError.missingPositions
+        }
+
+        let payloadStart = headerEndRange.upperBound
+        guard payloadStart + vertexCount * stride <= data.count else {
+            throw PLYReaderError.truncatedPayload
+        }
+
+        var positions = [SIMD3<Float>]()
+        positions.reserveCapacity(vertexCount)
+        for vertex in 0..<vertexCount {
+            let base = payloadStart + vertex * stride
+            positions.append(SIMD3<Float>(
+                readFloat(data, at: base + xOffset),
+                readFloat(data, at: base + yOffset),
+                readFloat(data, at: base + zOffset)
+            ))
+        }
+        return positions
+    }
+
+    private static func propertySize(_ type: String) throws -> Int {
+        switch type {
+        case "char", "uchar", "int8", "uint8": return 1
+        case "short", "ushort", "int16", "uint16": return 2
+        case "int", "uint", "int32", "uint32", "float", "float32": return 4
+        case "double", "float64": return 8
+        default: throw PLYReaderError.unsupportedFormat(type)
+        }
+    }
+
+    private static func readFloat(_ data: Data, at offset: Int) -> Float {
+        var bits: UInt32 = 0
+        withUnsafeMutableBytes(of: &bits) { destination in
+            data.copyBytes(to: destination, from: offset..<(offset + 4))
+        }
+        return Float(bitPattern: UInt32(littleEndian: bits))
+    }
+}

--- a/RealityMarkKit/Sources/ModelFileIO/UsdzArchive.swift
+++ b/RealityMarkKit/Sources/ModelFileIO/UsdzArchive.swift
@@ -1,0 +1,246 @@
+import Foundation
+
+public enum UsdzArchiveError: Error, Equatable {
+    case notAZipArchive
+    case corruptArchive(String)
+    case compressedEntryUnsupported(String)
+    case entryTooLarge(String)
+}
+
+/// Minimal reader/writer for the zip subset usdz uses: stored (uncompressed)
+/// entries whose file data starts on a 64-byte boundary (padding lives in a
+/// local-header extra field, the same technique OpenUSD's writer uses).
+///
+/// Reading tolerates any stored zip; writing always produces spec-conformant
+/// alignment, so read → replace texture bytes → write is a safe round trip
+/// that leaves untouched entries byte-identical.
+public struct UsdzArchive {
+    public struct Entry {
+        public var name: String
+        public var data: Data
+        /// DOS mod time/date preserved from the source archive.
+        public var modTime: UInt16
+        public var modDate: UInt16
+
+        public init(name: String, data: Data, modTime: UInt16 = 0, modDate: UInt16 = 0) {
+            self.name = name
+            self.data = data
+            self.modTime = modTime
+            self.modDate = modDate
+        }
+    }
+
+    public var entries: [Entry]
+
+    public init(entries: [Entry]) {
+        self.entries = entries
+    }
+
+    // MARK: - Reading
+
+    public static func read(url: URL) throws -> UsdzArchive {
+        try read(data: Data(contentsOf: url))
+    }
+
+    public static func read(data: Data) throws -> UsdzArchive {
+        guard let eocdOffset = findEndOfCentralDirectory(data) else {
+            throw UsdzArchiveError.notAZipArchive
+        }
+
+        let entryCount = Int(readUInt16(data, at: eocdOffset + 10))
+        let centralDirectoryOffset = Int(readUInt32(data, at: eocdOffset + 16))
+
+        var entries: [Entry] = []
+        var cursor = centralDirectoryOffset
+        for _ in 0..<entryCount {
+            guard cursor + 46 <= data.count,
+                  readUInt32(data, at: cursor) == 0x0201_4B50 else {
+                throw UsdzArchiveError.corruptArchive("central directory entry")
+            }
+
+            let method = readUInt16(data, at: cursor + 10)
+            let modTime = readUInt16(data, at: cursor + 12)
+            let modDate = readUInt16(data, at: cursor + 14)
+            let compressedSize = Int(readUInt32(data, at: cursor + 20))
+            let nameLength = Int(readUInt16(data, at: cursor + 28))
+            let extraLength = Int(readUInt16(data, at: cursor + 30))
+            let commentLength = Int(readUInt16(data, at: cursor + 32))
+            let localHeaderOffset = Int(readUInt32(data, at: cursor + 42))
+
+            guard cursor + 46 + nameLength <= data.count else {
+                throw UsdzArchiveError.corruptArchive("entry name")
+            }
+            let name = String(
+                decoding: data.subdata(in: (cursor + 46)..<(cursor + 46 + nameLength)),
+                as: UTF8.self
+            )
+
+            guard method == 0 else {
+                throw UsdzArchiveError.compressedEntryUnsupported(name)
+            }
+
+            guard localHeaderOffset + 30 <= data.count,
+                  readUInt32(data, at: localHeaderOffset) == 0x0403_4B50 else {
+                throw UsdzArchiveError.corruptArchive("local header for \(name)")
+            }
+            let localNameLength = Int(readUInt16(data, at: localHeaderOffset + 26))
+            let localExtraLength = Int(readUInt16(data, at: localHeaderOffset + 28))
+            let dataOffset = localHeaderOffset + 30 + localNameLength + localExtraLength
+            guard dataOffset + compressedSize <= data.count else {
+                throw UsdzArchiveError.corruptArchive("entry data for \(name)")
+            }
+
+            entries.append(Entry(
+                name: name,
+                data: data.subdata(in: dataOffset..<(dataOffset + compressedSize)),
+                modTime: modTime,
+                modDate: modDate
+            ))
+
+            cursor += 46 + nameLength + extraLength + commentLength
+        }
+
+        return UsdzArchive(entries: entries)
+    }
+
+    private static func findEndOfCentralDirectory(_ data: Data) -> Int? {
+        // EOCD is 22 bytes plus an up-to-64KB comment; scan backward.
+        let minOffset = max(0, data.count - 22 - 65_535)
+        guard data.count >= 22 else { return nil }
+        var offset = data.count - 22
+        while offset >= minOffset {
+            if readUInt32(data, at: offset) == 0x0605_4B50 {
+                return offset
+            }
+            offset -= 1
+        }
+        return nil
+    }
+
+    // MARK: - Writing
+
+    public func write(to url: URL) throws {
+        try serialized().write(to: url, options: .atomic)
+    }
+
+    public func serialized() throws -> Data {
+        var output = Data()
+        var centralRecords: [(entry: Entry, crc: UInt32, localHeaderOffset: Int)] = []
+
+        for entry in entries {
+            guard entry.data.count <= UInt32.max else {
+                throw UsdzArchiveError.entryTooLarge(entry.name)
+            }
+            let nameBytes = Array(entry.name.utf8)
+            let localHeaderOffset = output.count
+            let crc = CRC32.checksum(entry.data)
+
+            // Extra-field padding so the entry's data starts 64-byte aligned
+            // (usdz requirement). The 4-byte extra header itself counts.
+            let baseOffset = localHeaderOffset + 30 + nameBytes.count
+            let padding = (64 - (baseOffset + 4) % 64) % 64
+            let extraLength = 4 + padding
+
+            appendUInt32(&output, 0x0403_4B50)
+            appendUInt16(&output, 20)                       // version needed
+            appendUInt16(&output, 0)                        // flags
+            appendUInt16(&output, 0)                        // method: stored
+            appendUInt16(&output, entry.modTime)
+            appendUInt16(&output, entry.modDate)
+            appendUInt32(&output, crc)
+            appendUInt32(&output, UInt32(entry.data.count)) // compressed
+            appendUInt32(&output, UInt32(entry.data.count)) // uncompressed
+            appendUInt16(&output, UInt16(nameBytes.count))
+            appendUInt16(&output, UInt16(extraLength))
+            output.append(contentsOf: nameBytes)
+            appendUInt16(&output, 0x1986)                   // OpenUSD padding field ID
+            appendUInt16(&output, UInt16(padding))
+            output.append(Data(count: padding))
+
+            assert(output.count % 64 == 0, "usdz entry data must be 64-byte aligned")
+            output.append(entry.data)
+
+            centralRecords.append((entry, crc, localHeaderOffset))
+        }
+
+        let centralDirectoryOffset = output.count
+        for (entry, crc, localHeaderOffset) in centralRecords {
+            let nameBytes = Array(entry.name.utf8)
+            appendUInt32(&output, 0x0201_4B50)
+            appendUInt16(&output, 20)                       // version made by
+            appendUInt16(&output, 20)                       // version needed
+            appendUInt16(&output, 0)                        // flags
+            appendUInt16(&output, 0)                        // method: stored
+            appendUInt16(&output, entry.modTime)
+            appendUInt16(&output, entry.modDate)
+            appendUInt32(&output, crc)
+            appendUInt32(&output, UInt32(entry.data.count))
+            appendUInt32(&output, UInt32(entry.data.count))
+            appendUInt16(&output, UInt16(nameBytes.count))
+            appendUInt16(&output, 0)                        // extra length
+            appendUInt16(&output, 0)                        // comment length
+            appendUInt16(&output, 0)                        // disk number
+            appendUInt16(&output, 0)                        // internal attrs
+            appendUInt32(&output, 0)                        // external attrs
+            appendUInt32(&output, UInt32(localHeaderOffset))
+            output.append(contentsOf: nameBytes)
+        }
+        let centralDirectorySize = output.count - centralDirectoryOffset
+
+        appendUInt32(&output, 0x0605_4B50)
+        appendUInt16(&output, 0)                            // disk number
+        appendUInt16(&output, 0)                            // central directory disk
+        appendUInt16(&output, UInt16(centralRecords.count))
+        appendUInt16(&output, UInt16(centralRecords.count))
+        appendUInt32(&output, UInt32(centralDirectorySize))
+        appendUInt32(&output, UInt32(centralDirectoryOffset))
+        appendUInt16(&output, 0)                            // comment length
+
+        return output
+    }
+
+    // MARK: - Byte helpers
+
+    private static func readUInt16(_ data: Data, at offset: Int) -> UInt16 {
+        var value: UInt16 = 0
+        withUnsafeMutableBytes(of: &value) { destination in
+            data.copyBytes(to: destination, from: offset..<(offset + 2))
+        }
+        return UInt16(littleEndian: value)
+    }
+
+    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
+        var value: UInt32 = 0
+        withUnsafeMutableBytes(of: &value) { destination in
+            data.copyBytes(to: destination, from: offset..<(offset + 4))
+        }
+        return UInt32(littleEndian: value)
+    }
+
+    private func appendUInt16(_ data: inout Data, _ value: UInt16) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+
+    private func appendUInt32(_ data: inout Data, _ value: UInt32) {
+        withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) }
+    }
+}
+
+/// Standard CRC-32 (IEEE 802.3), table-driven — avoids linking zlib.
+enum CRC32 {
+    private static let table: [UInt32] = (0..<256).map { index -> UInt32 in
+        var value = UInt32(index)
+        for _ in 0..<8 {
+            value = (value & 1) == 1 ? (0xEDB8_8320 ^ (value >> 1)) : (value >> 1)
+        }
+        return value
+    }
+
+    static func checksum(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            crc = table[Int((crc ^ UInt32(byte)) & 0xFF)] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/GeometryWatermarker.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/GeometryWatermarker.swift
@@ -1,0 +1,262 @@
+import Foundation
+import simd
+
+public struct GeometryEmbedResult: Codable, Sendable, Equatable {
+    /// Bin count actually used after auto-fitting to the vertex count.
+    /// 0 means the channel was skipped (too few vertices or degenerate shape).
+    public var effectiveBinCount: Int
+    /// Bins that had enough members to carry a bit.
+    public var embeddedBits: Int
+    /// Largest vertex displacement introduced, in model units. Displacement is
+    /// purely radial and bounded by one bin width, so this stays imperceptible.
+    public var maxDisplacement: Float
+    public var bboxDiagonal: Float
+
+    public var isEmbedded: Bool { effectiveBinCount > 0 && embeddedBits > 0 }
+}
+
+public struct GeometryDetectionResult: Codable, Sendable, Equatable {
+    /// Bins that qualified at detection time.
+    public var totalBits: Int
+    public var matchedBits: Int
+    /// P[an unrelated key matches ≥ matchedBits of totalBits] (binomial tail).
+    public var pValue: Double
+}
+
+/// Blind keyed watermark on the distribution of vertex radial norms
+/// (Cho–Prost–Jung, IEEE Trans. Signal Processing 2007), keyed per copy.
+///
+/// Norms are translation-normalized against the centroid and scale-normalized
+/// against the norm range, so detection is invariant to vertex reordering,
+/// translation, rotation, and uniform scaling, and needs only the position
+/// multiset — no topology. The key drives both the expected bit per bin and a
+/// bin permutation; without it the embedded pattern is statistically invisible.
+public enum GeometryWatermarker {
+    static let bitsContext = "rp-wm/1/geo/bits"
+    static let permutationContext = "rp-wm/1/geo/perm"
+    static let minBinCount = 16
+
+    // MARK: - Embedding
+
+    public static func embed(
+        positions: inout [SIMD3<Float>],
+        key: WatermarkKey,
+        parameters: GeometryWatermarkParameters
+    ) -> GeometryEmbedResult {
+        guard let field = RadialField(positions: positions, trimFraction: parameters.trimFraction) else {
+            return GeometryEmbedResult(
+                effectiveBinCount: 0, embeddedBits: 0,
+                maxDisplacement: 0, bboxDiagonal: RadialField.bboxDiagonal(of: positions)
+            )
+        }
+
+        let binCount = fittedBinCount(
+            requested: parameters.binCount,
+            vertexCount: positions.count,
+            minVerticesPerBin: parameters.minVerticesPerBin
+        )
+        guard let binCount else {
+            return GeometryEmbedResult(
+                effectiveBinCount: 0, embeddedBits: 0,
+                maxDisplacement: 0, bboxDiagonal: field.bboxDiagonal
+            )
+        }
+
+        let expectedBits = expectedBits(key: key, binCount: binCount)
+        let bins = field.binMembers(binCount: binCount)
+
+        var embeddedBits = 0
+        var maxDisplacement = 0.0
+        for bin in 0..<binCount {
+            let members = bins[bin]
+            guard members.count >= parameters.minVerticesPerBin else { continue }
+
+            let locals = members.map { field.localCoordinate(of: $0, bin: bin, binCount: binCount) }
+            let target = expectedBits[bin] ? 0.5 + parameters.strength : 0.5 - parameters.strength
+            let exponent = solveExponent(
+                values: locals,
+                target: target,
+                maxIterations: parameters.maxIterations,
+                tolerance: parameters.meanTolerance
+            )
+
+            for (memberIndex, local) in zip(members, locals) {
+                let newNorm = field.norm(fromLocal: pow(local, exponent), bin: bin, binCount: binCount)
+                let displacement = abs(newNorm - field.norms[memberIndex])
+                maxDisplacement = max(maxDisplacement, displacement)
+                positions[memberIndex] = field.position(positions[memberIndex], scaledToNorm: newNorm, memberIndex: memberIndex)
+            }
+            embeddedBits += 1
+        }
+
+        return GeometryEmbedResult(
+            effectiveBinCount: binCount,
+            embeddedBits: embeddedBits,
+            maxDisplacement: Float(maxDisplacement),
+            bboxDiagonal: field.bboxDiagonal
+        )
+    }
+
+    // MARK: - Detection
+
+    /// `parameters.binCount` must be the `effectiveBinCount` recorded at embed
+    /// time (see `WatermarkRecord.GeometryChannelInfo.detectionParameters`).
+    public static func detect(
+        positions: [SIMD3<Float>],
+        key: WatermarkKey,
+        parameters: GeometryWatermarkParameters
+    ) -> GeometryDetectionResult {
+        guard parameters.binCount > 0,
+              let field = RadialField(positions: positions, trimFraction: parameters.trimFraction) else {
+            return GeometryDetectionResult(totalBits: 0, matchedBits: 0, pValue: 1)
+        }
+
+        let binCount = parameters.binCount
+        let expectedBits = expectedBits(key: key, binCount: binCount)
+        let bins = field.binMembers(binCount: binCount)
+
+        var totalBits = 0
+        var matchedBits = 0
+        for bin in 0..<binCount {
+            let members = bins[bin]
+            guard members.count >= parameters.minVerticesPerBin else { continue }
+
+            var sum = 0.0
+            for memberIndex in members {
+                sum += field.localCoordinate(of: memberIndex, bin: bin, binCount: binCount)
+            }
+            let extractedBit = (sum / Double(members.count)) > 0.5
+            totalBits += 1
+            if extractedBit == expectedBits[bin] { matchedBits += 1 }
+        }
+
+        return GeometryDetectionResult(
+            totalBits: totalBits,
+            matchedBits: matchedBits,
+            pValue: WatermarkStatistics.binomialTailPValue(matched: matchedBits, total: totalBits)
+        )
+    }
+
+    // MARK: - Shared keyed decisions
+
+    /// Expected bit per bin: PRF bit sequence read through a keyed permutation.
+    static func expectedBits(key: WatermarkKey, binCount: Int) -> [Bool] {
+        var permutationPRF = KeyedPRF(key: key, context: permutationContext)
+        let permutation = permutationPRF.permutation(count: binCount)
+        var bitsPRF = KeyedPRF(key: key, context: bitsContext)
+        let rawBits = (0..<binCount).map { _ in bitsPRF.nextBit() }
+        return (0..<binCount).map { rawBits[permutation[$0]] }
+    }
+
+    static func fittedBinCount(requested: Int, vertexCount: Int, minVerticesPerBin: Int) -> Int? {
+        var binCount = requested
+        while vertexCount < binCount * minVerticesPerBin && binCount > minBinCount {
+            binCount /= 2
+        }
+        return vertexCount >= binCount * minVerticesPerBin ? binCount : nil
+    }
+
+    /// Bisect k so that mean(xᵏ) hits the target; mean(xᵏ) is monotonically
+    /// decreasing in k for x ∈ [0, 1].
+    static func solveExponent(values: [Double], target: Double, maxIterations: Int, tolerance: Double) -> Double {
+        func mean(exponent: Double) -> Double {
+            values.reduce(0) { $0 + pow($1, exponent) } / Double(values.count)
+        }
+        var low = -6.0
+        var high = 6.0
+        for _ in 0..<maxIterations {
+            let mid = (low + high) / 2
+            let value = mean(exponent: exp2(mid))
+            if abs(value - target) <= tolerance { return exp2(mid) }
+            if value > target {
+                low = mid
+            } else {
+                high = mid
+            }
+        }
+        return exp2((low + high) / 2)
+    }
+}
+
+/// Centroid-relative radial norms normalized over a trimmed-quantile range —
+/// the invariant coordinate system shared by embedding and detection.
+struct RadialField {
+    let centroid: SIMD3<Double>
+    let norms: [Double]
+    /// Trimmed lower/upper quantiles of the norm distribution.
+    let lowerNorm: Double
+    let upperNorm: Double
+    let bboxDiagonal: Float
+
+    var normRange: Double { upperNorm - lowerNorm }
+
+    init?(positions: [SIMD3<Float>], trimFraction: Double) {
+        guard positions.count > 1 else { return nil }
+
+        var sum = SIMD3<Double>()
+        for position in positions {
+            sum += SIMD3<Double>(position)
+        }
+        let centroid = sum / Double(positions.count)
+
+        var norms = [Double]()
+        norms.reserveCapacity(positions.count)
+        for position in positions {
+            norms.append(simd_length(SIMD3<Double>(position) - centroid))
+        }
+
+        let sorted = norms.sorted()
+        let trim = max(0, min(trimFraction, 0.25))
+        let lastIndex = Double(sorted.count - 1)
+        let lowerNorm = sorted[Int(trim * lastIndex)]
+        let upperNorm = sorted[Int((1 - trim) * lastIndex)]
+        guard upperNorm - lowerNorm > .ulpOfOne else { return nil }
+
+        self.centroid = centroid
+        self.norms = norms
+        self.lowerNorm = lowerNorm
+        self.upperNorm = upperNorm
+        self.bboxDiagonal = Self.bboxDiagonal(of: positions)
+    }
+
+    static func bboxDiagonal(of positions: [SIMD3<Float>]) -> Float {
+        guard var minCorner = positions.first else { return 0 }
+        var maxCorner = minCorner
+        for position in positions {
+            minCorner = simd_min(minCorner, position)
+            maxCorner = simd_max(maxCorner, position)
+        }
+        return simd_length(maxCorner - minCorner)
+    }
+
+    /// Vertices whose norms fall outside the trimmed range are excluded.
+    func binMembers(binCount: Int) -> [[Int]] {
+        var bins = [[Int]](repeating: [], count: binCount)
+        for (index, norm) in norms.enumerated() {
+            let normalized = (norm - lowerNorm) / normRange
+            guard normalized >= 0, normalized < 1 else { continue }
+            let bin = min(Int(normalized * Double(binCount)), binCount - 1)
+            bins[bin].append(index)
+        }
+        return bins
+    }
+
+    /// Position of the norm within its bin, in [0, 1].
+    func localCoordinate(of index: Int, bin: Int, binCount: Int) -> Double {
+        let normalized = (norms[index] - lowerNorm) / normRange
+        return normalized * Double(binCount) - Double(bin)
+    }
+
+    func norm(fromLocal local: Double, bin: Int, binCount: Int) -> Double {
+        let normalized = (Double(bin) + local) / Double(binCount)
+        return lowerNorm + normalized * normRange
+    }
+
+    /// Radially rescale a position to the given centroid-relative norm.
+    func position(_ position: SIMD3<Float>, scaledToNorm newNorm: Double, memberIndex: Int) -> SIMD3<Float> {
+        let oldNorm = norms[memberIndex]
+        guard oldNorm > .ulpOfOne else { return position }
+        let scaled = centroid + (SIMD3<Double>(position) - centroid) * (newNorm / oldNorm)
+        return SIMD3<Float>(scaled)
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/KeyedPRF.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/KeyedPRF.swift
@@ -1,0 +1,82 @@
+import CryptoKit
+import Foundation
+
+/// Deterministic keyed pseudorandom stream: block_i = HMAC-SHA256(key, context ‖ LE64(i)).
+///
+/// Domain separation comes from the context string, so independent decisions
+/// (geometry bits, bin permutation, texture chips) draw from independent
+/// streams even under the same key.
+public struct KeyedPRF {
+    private let key: SymmetricKey
+    private let contextTag: [UInt8]
+    private var blockIndex: UInt64 = 0
+    private var buffer: [UInt8] = []
+    private var bufferOffset = 0
+    private var bitBuffer: UInt8 = 0
+    private var bitsRemaining = 0
+
+    public init(key: WatermarkKey, context: String) {
+        self.key = SymmetricKey(data: key.data)
+        self.contextTag = Array(context.utf8)
+    }
+
+    private mutating func refill() {
+        var message = contextTag
+        withUnsafeBytes(of: blockIndex.littleEndian) { message.append(contentsOf: $0) }
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(message), using: key)
+        buffer = Array(mac)
+        bufferOffset = 0
+        blockIndex += 1
+    }
+
+    public mutating func nextByte() -> UInt8 {
+        if bufferOffset >= buffer.count { refill() }
+        defer { bufferOffset += 1 }
+        return buffer[bufferOffset]
+    }
+
+    public mutating func nextBit() -> Bool {
+        if bitsRemaining == 0 {
+            bitBuffer = nextByte()
+            bitsRemaining = 8
+        }
+        let bit = bitBuffer & 1
+        bitBuffer >>= 1
+        bitsRemaining -= 1
+        return bit == 1
+    }
+
+    /// ±1 chip for spread-spectrum embedding.
+    public mutating func nextChip() -> Float {
+        nextBit() ? 1 : -1
+    }
+
+    public mutating func nextUInt64() -> UInt64 {
+        var value: UInt64 = 0
+        for _ in 0..<8 {
+            value = (value << 8) | UInt64(nextByte())
+        }
+        return value
+    }
+
+    /// Unbiased integer in 0..<upperBound via rejection sampling.
+    public mutating func next(upperBound: Int) -> Int {
+        precondition(upperBound > 0)
+        let bound = UInt64(upperBound)
+        let limit = UInt64.max - UInt64.max % bound
+        while true {
+            let value = nextUInt64()
+            if value < limit { return Int(value % bound) }
+        }
+    }
+
+    /// Keyed Fisher–Yates permutation of 0..<count.
+    public mutating func permutation(count: Int) -> [Int] {
+        var permutation = Array(0..<count)
+        guard count > 1 else { return permutation }
+        for i in stride(from: count - 1, through: 1, by: -1) {
+            permutation.swapAt(i, next(upperBound: i + 1))
+        }
+        return permutation
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/TextureWatermarker.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/TextureWatermarker.swift
@@ -1,0 +1,336 @@
+import CoreGraphics
+import Foundation
+
+public struct TextureDetectionResult: Codable, Sendable, Equatable {
+    /// Normalized correlation between the keyed chip sequence and the observed
+    /// mid-band coefficients (zScore / √chipCount).
+    public var correlation: Double
+    /// Σ chipᵢ·coefficientᵢ / √(Σ coefficientᵢ²) — standard normal under the
+    /// null hypothesis that the image was not marked with this key.
+    public var zScore: Double
+    /// One-sided normal tail P[Z ≥ zScore].
+    public var pValue: Double
+    public var chipCount: Int
+}
+
+/// Blind keyed additive spread-spectrum watermark in the mid-band DCT
+/// coefficients of the luma plane.
+///
+/// Each complete 8×8 block carries one keyed ±1 chip per mid-band coefficient.
+/// The amplitude is far below visibility (PSNR ≥ ~45 dB) but with tens of
+/// thousands of chips the correlation statistic survives PNG/JPEG re-encoding
+/// and mild rescaling (the detector resamples the suspect image back to the
+/// recorded original size before correlating).
+public enum TextureWatermarker {
+    static let chipsContext = "rp-wm/1/tex/chips"
+
+    // MARK: - Embedding
+
+    public static func embed(
+        image: CGImage,
+        key: WatermarkKey,
+        parameters: TextureWatermarkParameters
+    ) throws -> CGImage {
+        guard var raster = RGBARaster(image: image) else { throw WatermarkError.unsupportedImage }
+
+        var luma = raster.lumaPlane()
+        let original = luma
+        modulateBlocks(luma: &luma, width: raster.width, height: raster.height, key: key, parameters: parameters) {
+            dct, chip in
+            dct + parameters.amplitude * chip
+        }
+
+        raster.addLumaDelta(current: luma, original: original)
+        guard let stamped = raster.makeImage() else { throw WatermarkError.unsupportedImage }
+        return stamped
+    }
+
+    // MARK: - Detection
+
+    /// Pass the record's original pixel size so a rescaled suspect image is
+    /// resampled back onto the embedding block grid first.
+    public static func detect(
+        image: CGImage,
+        key: WatermarkKey,
+        parameters: TextureWatermarkParameters,
+        originalSize: (width: Int, height: Int)? = nil
+    ) -> TextureDetectionResult {
+        var sourceImage = image
+        if let originalSize,
+           originalSize.width > 0, originalSize.height > 0,
+           originalSize.width != image.width || originalSize.height != image.height,
+           let resampled = RGBARaster.resample(image, width: originalSize.width, height: originalSize.height) {
+            sourceImage = resampled
+        }
+
+        guard let raster = RGBARaster(image: sourceImage) else {
+            return TextureDetectionResult(correlation: 0, zScore: 0, pValue: 1, chipCount: 0)
+        }
+
+        var luma = raster.lumaPlane()
+        var chipProduct = 0.0
+        var coefficientEnergy = 0.0
+        var chipCount = 0
+        modulateBlocks(luma: &luma, width: raster.width, height: raster.height, key: key, parameters: parameters) {
+            dct, chip in
+            chipProduct += Double(chip) * Double(dct)
+            coefficientEnergy += Double(dct) * Double(dct)
+            chipCount += 1
+            return dct
+        }
+
+        guard chipCount > 0, coefficientEnergy > .ulpOfOne else {
+            return TextureDetectionResult(correlation: 0, zScore: 0, pValue: 0.5, chipCount: chipCount)
+        }
+        let zScore = chipProduct / coefficientEnergy.squareRoot()
+        return TextureDetectionResult(
+            correlation: zScore / Double(chipCount).squareRoot(),
+            zScore: zScore,
+            pValue: WatermarkStatistics.normalUpperTailPValue(z: zScore),
+            chipCount: chipCount
+        )
+    }
+
+    // MARK: - Shared block scan
+
+    /// Walks every complete block in row-major order, visiting the mid-band
+    /// coefficients in zigzag order with their keyed chips — the exact same
+    /// traversal for embed and detect, so the PRF streams stay aligned.
+    private static func modulateBlocks(
+        luma: inout [Float],
+        width: Int,
+        height: Int,
+        key: WatermarkKey,
+        parameters: TextureWatermarkParameters,
+        transform: (Float, Float) -> Float
+    ) {
+        let blockSize = parameters.blockSize
+        guard blockSize == 8 else { return }
+        let midBand = DCT8x8.zigzagPositions(in: parameters.midBandRange)
+        guard !midBand.isEmpty else { return }
+
+        let blocksX = width / blockSize
+        let blocksY = height / blockSize
+        var prf = KeyedPRF(key: key, context: chipsContext)
+        var block = [Float](repeating: 0, count: blockSize * blockSize)
+        var coefficients = [Float](repeating: 0, count: blockSize * blockSize)
+
+        for blockY in 0..<blocksY {
+            for blockX in 0..<blocksX {
+                let originX = blockX * blockSize
+                let originY = blockY * blockSize
+                for row in 0..<blockSize {
+                    let sourceOffset = (originY + row) * width + originX
+                    for column in 0..<blockSize {
+                        block[row * blockSize + column] = luma[sourceOffset + column]
+                    }
+                }
+
+                DCT8x8.forward(block, into: &coefficients)
+                var changed = false
+                for position in midBand {
+                    let chip = prf.nextChip()
+                    let updated = transform(coefficients[position], chip)
+                    if updated != coefficients[position] {
+                        coefficients[position] = updated
+                        changed = true
+                    }
+                }
+                guard changed else { continue }
+
+                DCT8x8.inverse(coefficients, into: &block)
+                for row in 0..<blockSize {
+                    let destinationOffset = (originY + row) * width + originX
+                    for column in 0..<blockSize {
+                        luma[destinationOffset + column] = block[row * blockSize + column]
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Orthonormal 8×8 DCT-II with precomputed basis.
+enum DCT8x8 {
+    static let size = 8
+
+    static let basis: [Float] = {
+        var basis = [Float](repeating: 0, count: size * size)
+        for k in 0..<size {
+            let scale = k == 0 ? (1.0 / Double(size)).squareRoot() : (2.0 / Double(size)).squareRoot()
+            for n in 0..<size {
+                basis[k * size + n] = Float(scale * cos(Double.pi * (2 * Double(n) + 1) * Double(k) / (2 * Double(size))))
+            }
+        }
+        return basis
+    }()
+
+    /// Row-major zigzag scan positions of an 8×8 block.
+    static let zigzagOrder: [Int] = {
+        var order = [Int]()
+        for diagonal in 0..<(2 * size - 1) {
+            var indices = [Int]()
+            for row in 0..<size {
+                let column = diagonal - row
+                if (0..<size).contains(column) {
+                    indices.append(row * size + column)
+                }
+            }
+            order.append(contentsOf: diagonal % 2 == 0 ? indices.reversed() : indices)
+        }
+        return order
+    }()
+
+    static func zigzagPositions(in range: ClosedRange<Int>) -> [Int] {
+        let clamped = max(0, range.lowerBound)...min(zigzagOrder.count - 1, range.upperBound)
+        guard clamped.lowerBound <= clamped.upperBound else { return [] }
+        return clamped.map { zigzagOrder[$0] }
+    }
+
+    /// D = C · X · Cᵀ
+    static func forward(_ block: [Float], into output: inout [Float]) {
+        let temporary = multiplyAB(basis, block)
+        output = multiplyABt(temporary, basis)
+    }
+
+    /// X = Cᵀ · D · C
+    static func inverse(_ coefficients: [Float], into output: inout [Float]) {
+        let temporary = multiplyAtB(basis, coefficients)
+        output = multiplyAB(temporary, basis)
+    }
+
+    private static func multiplyAB(_ a: [Float], _ b: [Float]) -> [Float] {
+        var output = [Float](repeating: 0, count: size * size)
+        for row in 0..<size {
+            for column in 0..<size {
+                var sum: Float = 0
+                for k in 0..<size {
+                    sum += a[row * size + k] * b[k * size + column]
+                }
+                output[row * size + column] = sum
+            }
+        }
+        return output
+    }
+
+    private static func multiplyABt(_ a: [Float], _ b: [Float]) -> [Float] {
+        var output = [Float](repeating: 0, count: size * size)
+        for row in 0..<size {
+            for column in 0..<size {
+                var sum: Float = 0
+                for k in 0..<size {
+                    sum += a[row * size + k] * b[column * size + k]
+                }
+                output[row * size + column] = sum
+            }
+        }
+        return output
+    }
+
+    private static func multiplyAtB(_ a: [Float], _ b: [Float]) -> [Float] {
+        var output = [Float](repeating: 0, count: size * size)
+        for row in 0..<size {
+            for column in 0..<size {
+                var sum: Float = 0
+                for k in 0..<size {
+                    sum += a[k * size + row] * b[k * size + column]
+                }
+                output[row * size + column] = sum
+            }
+        }
+        return output
+    }
+}
+
+/// RGBA8 pixel buffer with luma extraction and delta write-back.
+struct RGBARaster {
+    let width: Int
+    let height: Int
+    var pixels: [UInt8]
+
+    init?(image: CGImage) {
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let drawn = pixels.withUnsafeMutableBytes { buffer -> Bool in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else { return false }
+            context.interpolationQuality = .none
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard drawn else { return nil }
+
+        self.width = width
+        self.height = height
+        self.pixels = pixels
+    }
+
+    static func resample(_ image: CGImage, width: Int, height: Int) -> CGImage? {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()
+    }
+
+    /// BT.601 luma on the 0–255 scale.
+    func lumaPlane() -> [Float] {
+        var luma = [Float](repeating: 0, count: width * height)
+        for pixel in 0..<(width * height) {
+            let offset = pixel * 4
+            luma[pixel] = 0.299 * Float(pixels[offset])
+                + 0.587 * Float(pixels[offset + 1])
+                + 0.114 * Float(pixels[offset + 2])
+        }
+        return luma
+    }
+
+    /// Distributes the per-pixel luma change equally onto R, G, B with clamping.
+    mutating func addLumaDelta(current: [Float], original: [Float]) {
+        for pixel in 0..<(width * height) {
+            let delta = current[pixel] - original[pixel]
+            guard abs(delta) > 1e-4 else { continue }
+            let offset = pixel * 4
+            for channel in 0..<3 {
+                let value = Float(pixels[offset + channel]) + delta
+                pixels[offset + channel] = UInt8(min(255, max(0, value.rounded())))
+            }
+        }
+    }
+
+    func makeImage() -> CGImage? {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        var pixels = pixels
+        return pixels.withUnsafeMutableBytes { buffer -> CGImage? in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else { return nil }
+            return context.makeImage()
+        }
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/WatermarkKey.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/WatermarkKey.swift
@@ -1,0 +1,28 @@
+import CryptoKit
+import Foundation
+
+public enum WatermarkError: Error, Equatable {
+    case invalidKeyLength
+    case unsupportedImage
+}
+
+/// A per-copy 256-bit secret key. Following Kerckhoffs's principle, this key is
+/// the only secret in the system: the embedding and detection algorithms are
+/// public, and every keyed decision (bit sequence, bin permutation, chip signs)
+/// is derived from this key through an HMAC-SHA256 PRF.
+public struct WatermarkKey: Sendable, Equatable {
+    public static let byteCount = 32
+
+    public let data: Data
+
+    public init(data: Data) throws {
+        guard data.count == Self.byteCount else { throw WatermarkError.invalidKeyLength }
+        self.data = data
+    }
+
+    public static func random() -> WatermarkKey {
+        let key = SymmetricKey(size: .bits256)
+        let data = key.withUnsafeBytes { Data($0) }
+        return try! WatermarkKey(data: data)
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/WatermarkParameters.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/WatermarkParameters.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Parameters for the geometry channel (keyed Cho–Prost–Jung vertex-norm
+/// distribution watermark). All values are public; they are stored in the
+/// export record so detection replays the exact embedding configuration.
+public struct GeometryWatermarkParameters: Codable, Sendable, Equatable {
+    /// Requested number of norm bins (one embedded bit per bin). The embedder
+    /// halves this (floor 16) until every bin can expect `minVerticesPerBin`
+    /// members; the count actually used is recorded as `effectiveBinCount`.
+    public var binCount: Int
+    /// Target |bin mean − 0.5| after embedding (α).
+    public var strength: Double
+    /// Bins with fewer members are skipped at embed and detect time.
+    public var minVerticesPerBin: Int
+    /// Bisection iterations for the power-law exponent search.
+    public var maxIterations: Int
+    /// Acceptable deviation from the target bin mean.
+    public var meanTolerance: Double
+    /// Fraction trimmed from each end of the norm distribution before the bin
+    /// range is derived. Trimmed quantiles barely move under noise, re-save
+    /// quantization, or subsampling, whereas the raw min/max shift by several
+    /// σ and would drag every bin edge with them. Vertices outside the trimmed
+    /// range are excluded from embedding and detection.
+    public var trimFraction: Double
+
+    public init(
+        binCount: Int = 64,
+        strength: Double = 0.04,
+        minVerticesPerBin: Int = 32,
+        maxIterations: Int = 30,
+        meanTolerance: Double = 0.005,
+        trimFraction: Double = 0.005
+    ) {
+        self.binCount = binCount
+        self.strength = strength
+        self.minVerticesPerBin = minVerticesPerBin
+        self.maxIterations = maxIterations
+        self.meanTolerance = meanTolerance
+        self.trimFraction = trimFraction
+    }
+}
+
+/// Parameters for the texture channel (keyed additive spread spectrum in the
+/// mid-band DCT coefficients of the luma plane).
+public struct TextureWatermarkParameters: Codable, Sendable, Equatable {
+    /// DCT block edge length in pixels.
+    public var blockSize: Int
+    /// Zigzag indices (0 = DC) of the coefficients that carry chips.
+    public var midBandLowerIndex: Int
+    public var midBandUpperIndex: Int
+    /// Chip amplitude on the 0–255 luma DCT scale.
+    public var amplitude: Float
+
+    public var midBandRange: ClosedRange<Int> { midBandLowerIndex...midBandUpperIndex }
+
+    public init(
+        blockSize: Int = 8,
+        midBandLowerIndex: Int = 6,
+        midBandUpperIndex: Int = 27,
+        amplitude: Float = 2.0
+    ) {
+        self.blockSize = blockSize
+        self.midBandLowerIndex = midBandLowerIndex
+        self.midBandUpperIndex = midBandUpperIndex
+        self.amplitude = amplitude
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/WatermarkRecord.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/WatermarkRecord.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// The export record for a single watermarked file — the single source of
+/// truth shared by the app (SwiftData persistence, JSON export) and the
+/// internal `watermark-verify` CLI. Contains the per-copy secret key; record
+/// JSON files must be handled as secrets.
+public struct WatermarkRecord: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+    public static let currentAlgorithmVersion = 1
+
+    public enum Channel {
+        public static let geometry = "geometry"
+        public static let texture = "texture"
+    }
+
+    public struct GeometryChannelInfo: Codable, Sendable, Equatable {
+        public var parameters: GeometryWatermarkParameters
+        public var effectiveBinCount: Int
+        public var embeddedBits: Int
+
+        public init(parameters: GeometryWatermarkParameters, effectiveBinCount: Int, embeddedBits: Int) {
+            self.parameters = parameters
+            self.effectiveBinCount = effectiveBinCount
+            self.embeddedBits = embeddedBits
+        }
+
+        /// Embed-time parameters with the bin count the embedder actually used.
+        public var detectionParameters: GeometryWatermarkParameters {
+            var parameters = parameters
+            parameters.binCount = effectiveBinCount
+            return parameters
+        }
+    }
+
+    public struct TextureChannelInfo: Codable, Sendable, Equatable {
+        public struct Image: Codable, Sendable, Equatable {
+            /// Archive entry name or sidecar filename of the stamped image.
+            public var name: String
+            /// Material semantic, e.g. "baseColor".
+            public var semantic: String
+            /// Pixel dimensions at embed time — the registration anchor the
+            /// detector resamples a rescaled suspect image back to.
+            public var width: Int
+            public var height: Int
+
+            public init(name: String, semantic: String, width: Int, height: Int) {
+                self.name = name
+                self.semantic = semantic
+                self.width = width
+                self.height = height
+            }
+        }
+
+        public var parameters: TextureWatermarkParameters
+        public var images: [Image]
+
+        public init(parameters: TextureWatermarkParameters, images: [Image]) {
+            self.parameters = parameters
+            self.images = images
+        }
+    }
+
+    public var schemaVersion: Int
+    public var recordId: UUID
+    public var jobId: UUID
+    /// "usdz" | "gltf" | "glb" | "ply"
+    public var format: String
+    public var detailLevel: String
+    public var filename: String
+    /// Absolute path at export time; informational only.
+    public var filePath: String?
+    public var createdAt: Date
+    public var algorithmVersion: Int
+    /// The 32-byte per-copy secret key (base64 in JSON).
+    public var key: Data
+    /// Channels actually embedded in this file.
+    public var channels: [String]
+    public var geometry: GeometryChannelInfo?
+    public var texture: TextureChannelInfo?
+    /// SHA-256 of the final stamped file, for exact-copy short-circuit and
+    /// stamp idempotence.
+    public var fileSHA256: String
+
+    public init(
+        recordId: UUID = UUID(),
+        jobId: UUID,
+        format: String,
+        detailLevel: String,
+        filename: String,
+        filePath: String?,
+        createdAt: Date = Date(),
+        key: WatermarkKey,
+        channels: [String],
+        geometry: GeometryChannelInfo?,
+        texture: TextureChannelInfo?,
+        fileSHA256: String
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.recordId = recordId
+        self.jobId = jobId
+        self.format = format
+        self.detailLevel = detailLevel
+        self.filename = filename
+        self.filePath = filePath
+        self.createdAt = createdAt
+        self.algorithmVersion = Self.currentAlgorithmVersion
+        self.key = key.data
+        self.channels = channels
+        self.geometry = geometry
+        self.texture = texture
+        self.fileSHA256 = fileSHA256
+    }
+
+    public var watermarkKey: WatermarkKey {
+        get throws { try WatermarkKey(data: key) }
+    }
+}
+
+public extension WatermarkRecord {
+    static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    func jsonData() throws -> Data {
+        try Self.makeEncoder().encode(self)
+    }
+
+    init(jsonData: Data) throws {
+        self = try Self.makeDecoder().decode(WatermarkRecord.self, from: jsonData)
+    }
+}

--- a/RealityMarkKit/Sources/WatermarkCore/WatermarkRecord.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/WatermarkRecord.swift
@@ -71,8 +71,12 @@ public struct WatermarkRecord: Codable, Sendable, Equatable {
     public var filePath: String?
     public var createdAt: Date
     public var algorithmVersion: Int
-    /// The 32-byte per-copy secret key (base64 in JSON).
+    /// The 32-byte secret key (base64 in JSON).
     public var key: Data
+    /// Label of the saved key library entry when a reused key was used; nil
+    /// for the default of a fresh per-copy key. A shared key means this file
+    /// is traceable to the label, not to an individual copy.
+    public var keyLabel: String?
     /// Channels actually embedded in this file.
     public var channels: [String]
     public var geometry: GeometryChannelInfo?
@@ -90,6 +94,7 @@ public struct WatermarkRecord: Codable, Sendable, Equatable {
         filePath: String?,
         createdAt: Date = Date(),
         key: WatermarkKey,
+        keyLabel: String? = nil,
         channels: [String],
         geometry: GeometryChannelInfo?,
         texture: TextureChannelInfo?,
@@ -105,6 +110,7 @@ public struct WatermarkRecord: Codable, Sendable, Equatable {
         self.createdAt = createdAt
         self.algorithmVersion = Self.currentAlgorithmVersion
         self.key = key.data
+        self.keyLabel = keyLabel
         self.channels = channels
         self.geometry = geometry
         self.texture = texture

--- a/RealityMarkKit/Sources/WatermarkCore/WatermarkStatistics.swift
+++ b/RealityMarkKit/Sources/WatermarkCore/WatermarkStatistics.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public enum WatermarkStatistics {
+    /// P[X ≥ matched] for X ~ Binomial(total, ½) — the chance an unrelated key
+    /// (or unmarked model) matches at least this many bits.
+    public static func binomialTailPValue(matched: Int, total: Int) -> Double {
+        guard total > 0 else { return 1 }
+        let clamped = max(0, min(matched, total))
+        let logHalfPowN = -Double(total) * log(2)
+        var tail = 0.0
+        for k in clamped...total {
+            let logChoose = lgamma(Double(total) + 1)
+                - lgamma(Double(k) + 1)
+                - lgamma(Double(total - k) + 1)
+            tail += exp(logChoose + logHalfPowN)
+        }
+        return min(1, tail)
+    }
+
+    /// One-sided upper tail P[Z ≥ z] for Z ~ N(0, 1).
+    public static func normalUpperTailPValue(z: Double) -> Double {
+        0.5 * erfc(z / 2.0.squareRoot())
+    }
+}

--- a/RealityMarkKit/Sources/watermark-verify/SuspectLoader.swift
+++ b/RealityMarkKit/Sources/watermark-verify/SuspectLoader.swift
@@ -1,0 +1,90 @@
+import CoreGraphics
+import Foundation
+import ModelFileIO
+import ModelIO
+import WatermarkCore
+import simd
+
+/// Whatever detection-relevant content could be pulled out of a suspect file.
+struct Suspect {
+    var positions: [SIMD3<Float>]
+    var images: [(name: String, image: CGImage)]
+}
+
+enum SuspectLoaderError: Error, CustomStringConvertible {
+    case unsupportedFileType(String)
+    case nothingExtractable
+
+    var description: String {
+        switch self {
+        case .unsupportedFileType(let ext):
+            return "Unsupported suspect file type '.\(ext)' (expected usdz, glb, gltf, ply, png, or jpg)."
+        case .nothingExtractable:
+            return "No geometry or images could be extracted from the suspect file."
+        }
+    }
+}
+
+enum SuspectLoader {
+    static func load(url: URL) throws -> Suspect {
+        switch url.pathExtension.lowercased() {
+        case "usdz":
+            return try loadUSDZ(url: url)
+        case "glb", "gltf":
+            let asset = try MiniGLTFReader.read(url: url)
+            let images = asset.baseColorImages.enumerated().compactMap { index, data in
+                (try? ImageCodec.decode(data)).map { ("image\(index)", $0) }
+            }
+            return Suspect(positions: asset.positions, images: images)
+        case "ply":
+            return Suspect(positions: try PLYReader.readPositions(url: url), images: [])
+        case "png", "jpg", "jpeg":
+            let image = try ImageCodec.decode(Data(contentsOf: url))
+            return Suspect(positions: [], images: [(url.lastPathComponent, image)])
+        case let ext:
+            throw SuspectLoaderError.unsupportedFileType(ext)
+        }
+    }
+
+    // MARK: - USDZ
+
+    private static func loadUSDZ(url: URL) throws -> Suspect {
+        // Texture entries straight from the zip — no USD interpretation needed.
+        var images: [(name: String, image: CGImage)] = []
+        if let archive = try? UsdzArchive.read(url: url) {
+            for entry in archive.entries where ImageCodec.imageFormat(of: entry.data) != nil {
+                if let image = try? ImageCodec.decode(entry.data) {
+                    images.append((entry.name, image))
+                }
+            }
+        }
+
+        // Geometry via ModelIO (detection is invariant to node transforms that
+        // are rigid + uniform scale, so raw vertex positions suffice).
+        var positions: [SIMD3<Float>] = []
+        let asset = MDLAsset(url: url)
+        for index in 0..<asset.count {
+            collectPositions(from: asset.object(at: index), into: &positions)
+        }
+
+        guard !positions.isEmpty || !images.isEmpty else {
+            throw SuspectLoaderError.nothingExtractable
+        }
+        return Suspect(positions: positions, images: images)
+    }
+
+    private static func collectPositions(from object: MDLObject, into positions: inout [SIMD3<Float>]) {
+        if let mesh = object as? MDLMesh,
+           let attribute = mesh.vertexAttributeData(forAttributeNamed: MDLVertexAttributePosition, as: .float3) {
+            let base = attribute.map.bytes
+            for vertex in 0..<mesh.vertexCount {
+                let pointer = base.advanced(by: vertex * attribute.stride)
+                    .assumingMemoryBound(to: Float.self)
+                positions.append(SIMD3<Float>(pointer[0], pointer[1], pointer[2]))
+            }
+        }
+        for child in object.children.objects {
+            collectPositions(from: child, into: &positions)
+        }
+    }
+}

--- a/RealityMarkKit/Sources/watermark-verify/main.swift
+++ b/RealityMarkKit/Sources/watermark-verify/main.swift
@@ -1,0 +1,177 @@
+import CryptoKit
+import Foundation
+import WatermarkCore
+
+// watermark-verify — internal provenance checker for Reality Pulse exports.
+//
+//   watermark-verify --record <record.json> [--channel geometry|texture|both]
+//                    [--verbose] <suspect-file>
+//
+// Exit codes: 0 MATCH, 1 LIKELY, 2 NO MATCH, 3 usage/IO error.
+//
+// The algorithm is public; detection is possible only with the per-copy key
+// inside the record JSON. Treat record files as secrets.
+
+let usage = """
+usage: watermark-verify --record <record.json> [--channel geometry|texture|both] [--verbose] <suspect-file>
+"""
+
+var recordPath: String?
+var channelFilter = "both"
+var verbose = false
+var suspectPath: String?
+
+var arguments = Array(CommandLine.arguments.dropFirst())
+while !arguments.isEmpty {
+    let argument = arguments.removeFirst()
+    switch argument {
+    case "--record", "-r":
+        guard !arguments.isEmpty else { fail("--record requires a path") }
+        recordPath = arguments.removeFirst()
+    case "--channel", "-c":
+        guard !arguments.isEmpty else { fail("--channel requires geometry|texture|both") }
+        channelFilter = arguments.removeFirst()
+        guard ["geometry", "texture", "both"].contains(channelFilter) else {
+            fail("unknown channel '\(channelFilter)'")
+        }
+    case "--verbose", "-v":
+        verbose = true
+    case "--help", "-h":
+        print(usage)
+        exit(0)
+    default:
+        if argument.hasPrefix("-") { fail("unknown option '\(argument)'") }
+        guard suspectPath == nil else { fail("multiple suspect files given") }
+        suspectPath = argument
+    }
+}
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("watermark-verify: \(message)\n\(usage)\n".utf8))
+    exit(3)
+}
+
+guard let recordPath, let suspectPath else { fail("missing --record or suspect file") }
+
+let record: WatermarkRecord
+do {
+    record = try WatermarkRecord(jsonData: Data(contentsOf: URL(fileURLWithPath: recordPath)))
+} catch {
+    fail("could not read record: \(error)")
+}
+
+let key: WatermarkKey
+do {
+    key = try record.watermarkKey
+} catch {
+    fail("record contains an invalid key")
+}
+
+let suspectURL = URL(fileURLWithPath: suspectPath)
+let suspect: Suspect
+do {
+    suspect = try SuspectLoader.load(url: suspectURL)
+} catch {
+    fail("could not load suspect: \(error)")
+}
+
+print("watermark-verify — provenance check")
+print("record:   \(record.recordId) (\(record.format), \(record.detailLevel), \(record.filename))")
+print("suspect:  \(suspectPath)")
+
+// Exact-copy short-circuit.
+if let suspectData = try? Data(contentsOf: suspectURL, options: .mappedIfSafe) {
+    let sha = SHA256.hash(data: suspectData).map { String(format: "%02x", $0) }.joined()
+    if sha == record.fileSHA256 {
+        print("sha256:   EXACT byte-identical copy of the recorded export")
+        print("verdict:  MATCH (p = 0, exact copy)")
+        exit(0)
+    }
+    print("sha256:   differs from recorded export (expected for edited copies)")
+}
+
+var channelPValues: [Double] = []
+
+// Geometry channel.
+if channelFilter != "texture" {
+    if let geometry = record.geometry, !suspect.positions.isEmpty {
+        let detection = GeometryWatermarker.detect(
+            positions: suspect.positions,
+            key: key,
+            parameters: geometry.detectionParameters
+        )
+        channelPValues.append(detection.pValue)
+        print(String(
+            format: "geometry: matched %d/%d bits over %d points, p = %.3g",
+            detection.matchedBits, detection.totalBits, suspect.positions.count, detection.pValue
+        ))
+    } else if record.geometry == nil {
+        print("geometry: not embedded in this export (per record)")
+    } else {
+        print("geometry: suspect has no extractable point set")
+    }
+}
+
+// Texture channel: try every suspect image against every recorded image size,
+// keep the best score, and Bonferroni-adjust for the number of attempts.
+if channelFilter != "geometry" {
+    if let texture = record.texture, !suspect.images.isEmpty {
+        var best: (name: String, result: TextureDetectionResult)?
+        var attempts = 0
+        for (name, image) in suspect.images {
+            for recorded in texture.images {
+                attempts += 1
+                let result = TextureWatermarker.detect(
+                    image: image,
+                    key: key,
+                    parameters: texture.parameters,
+                    originalSize: (width: recorded.width, height: recorded.height)
+                )
+                if verbose {
+                    print(String(
+                        format: "  - %@ vs %@ (%dx%d): z = %.2f, p = %.3g",
+                        name, recorded.name, recorded.width, recorded.height,
+                        result.zScore, result.pValue
+                    ))
+                }
+                if best == nil || result.zScore > best!.result.zScore {
+                    best = (name, result)
+                }
+            }
+        }
+        if let best {
+            let adjusted = min(1, best.result.pValue * Double(attempts))
+            channelPValues.append(adjusted)
+            print(String(
+                format: "texture:  best image '%@': z = %.2f, p = %.3g (adjusted %.3g over %d attempt(s))",
+                best.name, best.result.zScore, best.result.pValue, adjusted, attempts
+            ))
+        }
+    } else if record.texture == nil {
+        print("texture:  not embedded in this export (per record)")
+    } else {
+        print("texture:  suspect has no extractable images")
+    }
+}
+
+guard !channelPValues.isEmpty else {
+    fail("no channel of this record is testable against this suspect")
+}
+
+// Combined verdict: best channel, Bonferroni-adjusted for channels tested.
+let combined = min(1, channelPValues.min()! * Double(channelPValues.count))
+let verdict: String
+let exitCode: Int32
+switch combined {
+case ..<1e-6:
+    verdict = "MATCH"
+    exitCode = 0
+case ..<1e-3:
+    verdict = "LIKELY"
+    exitCode = 1
+default:
+    verdict = "NO MATCH"
+    exitCode = 2
+}
+print(String(format: "verdict:  %@ (combined p = %.3g)", verdict, combined))
+exit(exitCode)

--- a/RealityMarkKit/Sources/watermark-verify/main.swift
+++ b/RealityMarkKit/Sources/watermark-verify/main.swift
@@ -77,6 +77,11 @@ do {
 
 print("watermark-verify — provenance check")
 print("record:   \(record.recordId) (\(record.format), \(record.detailLevel), \(record.filename))")
+if let keyLabel = record.keyLabel {
+    print("key:      shared key '\(keyLabel)' — identifies the key, not an individual copy")
+} else {
+    print("key:      per-copy key — identifies this exact exported file")
+}
 print("suspect:  \(suspectPath)")
 
 // Exact-copy short-circuit.

--- a/RealityMarkKit/Tests/ModelFileIOTests/ImageCodecTests.swift
+++ b/RealityMarkKit/Tests/ModelFileIOTests/ImageCodecTests.swift
@@ -1,0 +1,74 @@
+import CoreGraphics
+import XCTest
+@testable import ModelFileIO
+@testable import WatermarkCore
+
+final class ImageCodecTests: XCTestCase {
+    /// Photo-like synthetic texture (mirrors the WatermarkCoreTests fixture).
+    private func makeTestImage(width: Int, height: Int) -> CGImage {
+        var state: UInt64 = 99
+        func nextDouble() -> Double {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return Double((z ^ (z >> 31)) >> 11) * (1.0 / 9_007_199_254_740_992.0)
+        }
+
+        var pixels = [UInt8](repeating: 255, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                let gradient = 90.0 + 80.0 * Double(x) / Double(width)
+                let structure = 40.0 * sin(Double(x) * 0.11) * cos(Double(y) * 0.07)
+                let grain = (nextDouble() - 0.5) * 14
+                let offset = (y * width + x) * 4
+                pixels[offset] = UInt8(min(255, max(0, gradient + structure + grain)))
+                pixels[offset + 1] = UInt8(min(255, max(0, gradient * 0.8 + structure + grain)))
+                pixels[offset + 2] = UInt8(min(255, max(0, gradient * 0.6 - structure + grain)))
+            }
+        }
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        return pixels.withUnsafeMutableBytes { buffer in
+            CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )!.makeImage()!
+        }
+    }
+
+    func testPNGRoundTripIsLossless() throws {
+        let image = makeTestImage(width: 64, height: 64)
+        let decoded = try ImageCodec.decode(ImageCodec.pngData(from: image))
+        XCTAssertEqual(RGBARaster(image: decoded)!.pixels, RGBARaster(image: image)!.pixels)
+    }
+
+    func testImageFormatDetection() throws {
+        let image = makeTestImage(width: 16, height: 16)
+        XCTAssertEqual(ImageCodec.imageFormat(of: try ImageCodec.pngData(from: image)), .png)
+        XCTAssertEqual(ImageCodec.imageFormat(of: try ImageCodec.jpegData(from: image, quality: 0.9)), .jpeg)
+        XCTAssertNil(ImageCodec.imageFormat(of: Data([0x00, 0x01, 0x02, 0x03])))
+    }
+
+    func testWatermarkSurvivesJPEGReencode() throws {
+        let image = makeTestImage(width: 256, height: 256)
+        let key = try WatermarkKey(data: Data(repeating: 21, count: WatermarkKey.byteCount))
+        let parameters = TextureWatermarkParameters()
+        let stamped = try TextureWatermarker.embed(image: image, key: key, parameters: parameters)
+
+        // PNG → JPEG(q0.8) → decode, then detect.
+        let pngDecoded = try ImageCodec.decode(ImageCodec.pngData(from: stamped))
+        let jpegDecoded = try ImageCodec.decode(ImageCodec.jpegData(from: pngDecoded, quality: 0.8))
+
+        let detection = TextureWatermarker.detect(image: jpegDecoded, key: key, parameters: parameters)
+        XCTAssertLessThan(detection.pValue, 1e-6)
+
+        let wrongKey = try WatermarkKey(data: Data(repeating: 22, count: WatermarkKey.byteCount))
+        let wrongDetection = TextureWatermarker.detect(image: jpegDecoded, key: wrongKey, parameters: parameters)
+        XCTAssertGreaterThan(wrongDetection.pValue, 1e-3)
+    }
+}

--- a/RealityMarkKit/Tests/ModelFileIOTests/UsdzArchiveTests.swift
+++ b/RealityMarkKit/Tests/ModelFileIOTests/UsdzArchiveTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import ModelFileIO
+
+final class UsdzArchiveTests: XCTestCase {
+    private func makeArchive() -> UsdzArchive {
+        var payload = Data()
+        for index in 0..<10_000 {
+            payload.append(UInt8(truncatingIfNeeded: index &* 31 &+ 7))
+        }
+        return UsdzArchive(entries: [
+            .init(name: "model.usdc", data: payload, modTime: 0x6BCD, modDate: 0x58F1),
+            .init(name: "0/baked_mesh_tex0.png", data: Data([0x89, 0x50, 0x4E, 0x47]) + Data(count: 300)),
+            .init(name: "0/baked_mesh_norm0.png", data: Data([0x89, 0x50, 0x4E, 0x47]) + Data(count: 77)),
+        ])
+    }
+
+    func testRoundTripPreservesEntriesExactly() throws {
+        let archive = makeArchive()
+        let serialized = try archive.serialized()
+        let reread = try UsdzArchive.read(data: serialized)
+
+        XCTAssertEqual(reread.entries.count, 3)
+        for (original, roundTripped) in zip(archive.entries, reread.entries) {
+            XCTAssertEqual(roundTripped.name, original.name)
+            XCTAssertEqual(roundTripped.data, original.data)
+            XCTAssertEqual(roundTripped.modTime, original.modTime)
+            XCTAssertEqual(roundTripped.modDate, original.modDate)
+        }
+    }
+
+    func testEveryEntryDataOffsetIs64ByteAligned() throws {
+        let serialized = try makeArchive().serialized()
+
+        // Walk the local headers directly and check each data offset.
+        var offset = 0
+        var checked = 0
+        while offset + 30 <= serialized.count {
+            let signature = serialized.subdata(in: offset..<(offset + 4))
+            guard signature == Data([0x50, 0x4B, 0x03, 0x04]) else { break }
+            let nameLength = Int(serialized[offset + 26]) | (Int(serialized[offset + 27]) << 8)
+            let extraLength = Int(serialized[offset + 28]) | (Int(serialized[offset + 29]) << 8)
+            let sizeBytes = serialized.subdata(in: (offset + 18)..<(offset + 22))
+            let size = sizeBytes.withUnsafeBytes { $0.load(as: UInt32.self) }
+            let dataOffset = offset + 30 + nameLength + extraLength
+            XCTAssertEqual(dataOffset % 64, 0, "entry \(checked) data offset \(dataOffset)")
+            offset = dataOffset + Int(UInt32(littleEndian: size))
+            checked += 1
+        }
+        XCTAssertEqual(checked, 3)
+    }
+
+    func testUntouchedEntriesStayByteIdenticalAfterSelectiveEdit() throws {
+        var archive = makeArchive()
+        let originalUSDC = archive.entries[0].data
+        archive.entries[1].data = Data([0x89, 0x50, 0x4E, 0x47]) + Data(repeating: 0xAB, count: 500)
+
+        let reread = try UsdzArchive.read(data: try archive.serialized())
+        XCTAssertEqual(reread.entries[0].data, originalUSDC)
+        XCTAssertEqual(reread.entries[2].data, makeArchive().entries[2].data)
+        XCTAssertEqual(reread.entries[1].data.count, 504)
+    }
+
+    func testSystemUnzipAcceptsSerializedArchive() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let zipURL = directory.appending(path: "fixture.usdz")
+        try makeArchive().write(to: zipURL)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-t", zipURL.path]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(decoding: pipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0, "unzip -t rejected the archive: \(output)")
+    }
+
+    func testReadRejectsCompressedZip() throws {
+        // Build a zip with `zip` default (deflate) and confirm we refuse it.
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appending(path: "payload.txt")
+        try Data(repeating: 0x41, count: 4096).write(to: fileURL)
+        let zipURL = directory.appending(path: "compressed.zip")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-j", "-9", zipURL.path, fileURL.path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw XCTSkip("zip tool unavailable")
+        }
+
+        XCTAssertThrowsError(try UsdzArchive.read(url: zipURL)) { error in
+            guard case UsdzArchiveError.compressedEntryUnsupported = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testReadAcceptsStoredZipFromSystemTool() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appending(path: "payload.bin")
+        let payload = Data((0..<2048).map { UInt8(truncatingIfNeeded: $0) })
+        try payload.write(to: fileURL)
+        let zipURL = directory.appending(path: "stored.zip")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.arguments = ["-j", "-0", "-X", zipURL.path, fileURL.path]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw XCTSkip("zip tool unavailable")
+        }
+
+        let archive = try UsdzArchive.read(url: zipURL)
+        XCTAssertEqual(archive.entries.first?.name, "payload.bin")
+        XCTAssertEqual(archive.entries.first?.data, payload)
+    }
+
+    func testCRC32MatchesKnownVector() {
+        XCTAssertEqual(CRC32.checksum(Data("123456789".utf8)), 0xCBF4_3926)
+    }
+}

--- a/RealityMarkKit/Tests/WatermarkCoreTests/GeometryWatermarkTests.swift
+++ b/RealityMarkKit/Tests/WatermarkCoreTests/GeometryWatermarkTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+import simd
+@testable import WatermarkCore
+
+final class GeometryWatermarkTests: XCTestCase {
+    private let parameters = GeometryWatermarkParameters()
+
+    private func embeddedFixture(
+        count: Int = 50_000,
+        cloudSeed: UInt64 = 42,
+        keySeed: UInt8 = 11
+    ) -> (positions: [SIMD3<Float>], key: WatermarkKey, result: GeometryEmbedResult) {
+        var positions = Fixtures.blobCloud(count: count, seed: cloudSeed)
+        let key = Fixtures.key(seed: keySeed)
+        let result = GeometryWatermarker.embed(positions: &positions, key: key, parameters: parameters)
+        return (positions, key, result)
+    }
+
+    private func detectionParameters(for result: GeometryEmbedResult) -> GeometryWatermarkParameters {
+        var parameters = parameters
+        parameters.binCount = result.effectiveBinCount
+        return parameters
+    }
+
+    // MARK: - Roundtrip
+
+    func testEmbedDetectRoundTrip() {
+        let (positions, key, result) = embeddedFixture()
+        XCTAssertEqual(result.effectiveBinCount, 64)
+        XCTAssertGreaterThan(result.embeddedBits, 48)
+
+        let detection = GeometryWatermarker.detect(
+            positions: positions, key: key, parameters: detectionParameters(for: result)
+        )
+        XCTAssertGreaterThan(detection.totalBits, 48)
+        XCTAssertEqual(detection.matchedBits, detection.totalBits)
+        XCTAssertLessThan(detection.pValue, 1e-9)
+    }
+
+    func testSmallCloudAutoReducesBins() {
+        var positions = Fixtures.blobCloud(count: 900, seed: 5)
+        let key = Fixtures.key(seed: 4)
+        let result = GeometryWatermarker.embed(positions: &positions, key: key, parameters: parameters)
+        XCTAssertEqual(result.effectiveBinCount, 16)
+
+        let detection = GeometryWatermarker.detect(
+            positions: positions, key: key, parameters: detectionParameters(for: result)
+        )
+        XCTAssertLessThan(detection.pValue, 1e-3)
+    }
+
+    func testTinyOrDegenerateCloudSkipsChannel() {
+        var tiny = Fixtures.blobCloud(count: 100, seed: 9)
+        let tinyResult = GeometryWatermarker.embed(positions: &tiny, key: Fixtures.key(seed: 1), parameters: parameters)
+        XCTAssertEqual(tinyResult.effectiveBinCount, 0)
+        XCTAssertFalse(tinyResult.isEmbedded)
+
+        var degenerate = [SIMD3<Float>](repeating: SIMD3<Float>(1, 2, 3), count: 10_000)
+        let degenerateResult = GeometryWatermarker.embed(
+            positions: &degenerate, key: Fixtures.key(seed: 1), parameters: parameters
+        )
+        XCTAssertFalse(degenerateResult.isEmbedded)
+        XCTAssertEqual(degenerate, [SIMD3<Float>](repeating: SIMD3<Float>(1, 2, 3), count: 10_000))
+    }
+
+    // MARK: - Robustness
+
+    func testDetectionSurvivesGaussianNoise() {
+        let (positions, key, result) = embeddedFixture()
+        let sigma = Double(result.bboxDiagonal) * 0.001
+        let noisy = Fixtures.addGaussianNoise(positions, sigma: sigma, seed: 77)
+
+        let detection = GeometryWatermarker.detect(
+            positions: noisy, key: key, parameters: detectionParameters(for: result)
+        )
+        XCTAssertLessThan(detection.pValue, 1e-6)
+    }
+
+    func testDetectionSurvivesSimilarityTransform() {
+        let (positions, key, result) = embeddedFixture()
+        let transformed = Fixtures.similarityTransform(
+            positions,
+            angle: 1.1,
+            axis: SIMD3<Double>(0.3, 1.0, -0.5),
+            scale: 2.37,
+            translation: SIMD3<Double>(10, -4, 7.5)
+        )
+
+        let detection = GeometryWatermarker.detect(
+            positions: transformed, key: key, parameters: detectionParameters(for: result)
+        )
+        XCTAssertLessThan(detection.pValue, 1e-6)
+    }
+
+    func testDetectionSurvivesVertexReordering() {
+        let (positions, key, result) = embeddedFixture()
+        let shuffled = Fixtures.shuffled(positions, seed: 123)
+
+        let detection = GeometryWatermarker.detect(
+            positions: shuffled, key: key, parameters: detectionParameters(for: result)
+        )
+        XCTAssertEqual(detection.matchedBits, detection.totalBits)
+        XCTAssertLessThan(detection.pValue, 1e-9)
+    }
+
+    func testDetectionSurvivesFiftyPercentSubsample() {
+        let (positions, key, result) = embeddedFixture()
+        let subsampled = Fixtures.subsampled(positions, keepRatio: 0.5, seed: 321)
+        XCTAssertLessThan(subsampled.count, positions.count * 6 / 10)
+
+        let detection = GeometryWatermarker.detect(
+            positions: subsampled, key: key, parameters: detectionParameters(for: result)
+        )
+        XCTAssertLessThan(detection.pValue, 1e-6)
+    }
+
+    // MARK: - False positives
+
+    func testWrongKeysDetectAtChanceLevel() {
+        let (positions, _, result) = embeddedFixture()
+        let detectParameters = detectionParameters(for: result)
+
+        var matchRatios = [Double]()
+        for seed in 100..<200 {
+            var keyBytes = Data(repeating: UInt8(seed % 256), count: WatermarkKey.byteCount)
+            keyBytes[0] = UInt8(seed / 256)
+            let wrongKey = try! WatermarkKey(data: keyBytes)
+            let detection = GeometryWatermarker.detect(
+                positions: positions, key: wrongKey, parameters: detectParameters
+            )
+            XCTAssertGreaterThan(
+                detection.pValue, 1e-3,
+                "wrong key seed \(seed) matched \(detection.matchedBits)/\(detection.totalBits)"
+            )
+            matchRatios.append(Double(detection.matchedBits) / Double(detection.totalBits))
+        }
+
+        let meanRatio = matchRatios.reduce(0, +) / Double(matchRatios.count)
+        XCTAssertEqual(meanRatio, 0.5, accuracy: 0.05)
+    }
+
+    func testUnmarkedCloudDetectsAtChanceLevel() {
+        let positions = Fixtures.blobCloud(count: 50_000, seed: 42)
+        var detectParameters = parameters
+        detectParameters.binCount = 64
+        let detection = GeometryWatermarker.detect(
+            positions: positions, key: Fixtures.key(seed: 11), parameters: detectParameters
+        )
+        XCTAssertGreaterThan(detection.pValue, 1e-3)
+    }
+
+    // MARK: - Imperceptibility
+
+    func testDisplacementIsBoundedAndReportedAccurately() {
+        let original = Fixtures.blobCloud(count: 50_000, seed: 42)
+        var positions = original
+        let result = GeometryWatermarker.embed(
+            positions: &positions, key: Fixtures.key(seed: 11), parameters: parameters
+        )
+
+        var actualMax: Float = 0
+        for (before, after) in zip(original, positions) {
+            actualMax = max(actualMax, simd_length(after - before))
+        }
+        XCTAssertLessThanOrEqual(actualMax, result.maxDisplacement + 1e-5)
+        XCTAssertLessThanOrEqual(result.maxDisplacement, result.bboxDiagonal * 0.005)
+    }
+}

--- a/RealityMarkKit/Tests/WatermarkCoreTests/KeyedPRFTests.swift
+++ b/RealityMarkKit/Tests/WatermarkCoreTests/KeyedPRFTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import WatermarkCore
+
+final class KeyedPRFTests: XCTestCase {
+    func testStreamIsDeterministic() {
+        var first = KeyedPRF(key: Fixtures.key(seed: 7), context: "rp-wm/test")
+        var second = KeyedPRF(key: Fixtures.key(seed: 7), context: "rp-wm/test")
+        let firstBytes = (0..<128).map { _ in first.nextByte() }
+        let secondBytes = (0..<128).map { _ in second.nextByte() }
+        XCTAssertEqual(firstBytes, secondBytes)
+    }
+
+    func testDifferentKeysAndContextsDiverge() {
+        var base = KeyedPRF(key: Fixtures.key(seed: 7), context: "rp-wm/test")
+        var otherKey = KeyedPRF(key: Fixtures.key(seed: 8), context: "rp-wm/test")
+        var otherContext = KeyedPRF(key: Fixtures.key(seed: 7), context: "rp-wm/other")
+
+        let baseBytes = (0..<64).map { _ in base.nextByte() }
+        XCTAssertNotEqual(baseBytes, (0..<64).map { _ in otherKey.nextByte() })
+        XCTAssertNotEqual(baseBytes, (0..<64).map { _ in otherContext.nextByte() })
+    }
+
+    func testBitsAreRoughlyBalanced() {
+        var prf = KeyedPRF(key: Fixtures.key(seed: 3), context: "rp-wm/test")
+        let ones = (0..<10_000).filter { _ in prf.nextBit() }.count
+        XCTAssertGreaterThan(ones, 4_700)
+        XCTAssertLessThan(ones, 5_300)
+    }
+
+    func testBoundedDrawIsInRangeAndCoversValues() {
+        var prf = KeyedPRF(key: Fixtures.key(seed: 5), context: "rp-wm/test")
+        var seen = Set<Int>()
+        for _ in 0..<1_000 {
+            let value = prf.next(upperBound: 10)
+            XCTAssertTrue((0..<10).contains(value))
+            seen.insert(value)
+        }
+        XCTAssertEqual(seen.count, 10)
+    }
+
+    func testPermutationIsValidAndKeyDependent() {
+        var first = KeyedPRF(key: Fixtures.key(seed: 1), context: "rp-wm/test")
+        var second = KeyedPRF(key: Fixtures.key(seed: 2), context: "rp-wm/test")
+        let permutation = first.permutation(count: 64)
+        XCTAssertEqual(permutation.sorted(), Array(0..<64))
+        XCTAssertNotEqual(permutation, second.permutation(count: 64))
+    }
+}

--- a/RealityMarkKit/Tests/WatermarkCoreTests/TestSupport.swift
+++ b/RealityMarkKit/Tests/WatermarkCoreTests/TestSupport.swift
@@ -1,0 +1,95 @@
+import Foundation
+import simd
+@testable import WatermarkCore
+
+/// Deterministic PRNG for reproducible test fixtures (same generator family as
+/// the app's SurfaceSampler; not security-relevant).
+struct SplitMix64 {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    mutating func nextDouble() -> Double {
+        Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0)
+    }
+
+    mutating func nextGaussian() -> Double {
+        var u = nextDouble()
+        if u <= .ulpOfOne { u = .ulpOfOne }
+        let v = nextDouble()
+        return (-2 * log(u)).squareRoot() * cos(2 * .pi * v)
+    }
+}
+
+enum Fixtures {
+    /// Point cloud with a broad radial-norm distribution (radius uniform in
+    /// [0.2, 1.0] times a random direction) — shaped like the photogrammetry
+    /// meshes the watermark targets, unlike a thin spherical shell.
+    static func blobCloud(count: Int, seed: UInt64) -> [SIMD3<Float>] {
+        var rng = SplitMix64(seed: seed)
+        var positions = [SIMD3<Float>]()
+        positions.reserveCapacity(count)
+        for _ in 0..<count {
+            var direction = SIMD3<Double>(rng.nextGaussian(), rng.nextGaussian(), rng.nextGaussian())
+            let length = simd_length(direction)
+            direction = length > .ulpOfOne ? direction / length : SIMD3<Double>(1, 0, 0)
+            let radius = 0.2 + 0.8 * rng.nextDouble()
+            positions.append(SIMD3<Float>(direction * radius))
+        }
+        return positions
+    }
+
+    static func key(seed: UInt8) -> WatermarkKey {
+        try! WatermarkKey(data: Data(repeating: seed, count: WatermarkKey.byteCount))
+    }
+
+    static func addGaussianNoise(_ positions: [SIMD3<Float>], sigma: Double, seed: UInt64) -> [SIMD3<Float>] {
+        var rng = SplitMix64(seed: seed)
+        return positions.map { position in
+            position + SIMD3<Float>(
+                Float(rng.nextGaussian() * sigma),
+                Float(rng.nextGaussian() * sigma),
+                Float(rng.nextGaussian() * sigma)
+            )
+        }
+    }
+
+    static func similarityTransform(
+        _ positions: [SIMD3<Float>],
+        angle: Double,
+        axis: SIMD3<Double>,
+        scale: Double,
+        translation: SIMD3<Double>
+    ) -> [SIMD3<Float>] {
+        let rotation = simd_quatd(angle: angle, axis: simd_normalize(axis))
+        return positions.map { position in
+            let transformed = rotation.act(SIMD3<Double>(position)) * scale + translation
+            return SIMD3<Float>(transformed)
+        }
+    }
+
+    static func shuffled(_ positions: [SIMD3<Float>], seed: UInt64) -> [SIMD3<Float>] {
+        var rng = SplitMix64(seed: seed)
+        var shuffled = positions
+        for i in stride(from: shuffled.count - 1, through: 1, by: -1) {
+            let j = Int(rng.next() % UInt64(i + 1))
+            shuffled.swapAt(i, j)
+        }
+        return shuffled
+    }
+
+    static func subsampled(_ positions: [SIMD3<Float>], keepRatio: Double, seed: UInt64) -> [SIMD3<Float>] {
+        var rng = SplitMix64(seed: seed)
+        return positions.filter { _ in rng.nextDouble() < keepRatio }
+    }
+}

--- a/RealityMarkKit/Tests/WatermarkCoreTests/TextureWatermarkTests.swift
+++ b/RealityMarkKit/Tests/WatermarkCoreTests/TextureWatermarkTests.swift
@@ -1,0 +1,123 @@
+import CoreGraphics
+import XCTest
+@testable import WatermarkCore
+
+final class TextureWatermarkTests: XCTestCase {
+    private let parameters = TextureWatermarkParameters()
+
+    /// Photo-like synthetic texture: smooth gradients, structure, and grain.
+    static func makeTestImage(width: Int, height: Int, seed: UInt64) -> CGImage {
+        var rng = SplitMix64(seed: seed)
+        var pixels = [UInt8](repeating: 255, count: width * height * 4)
+        for y in 0..<height {
+            for x in 0..<width {
+                let gradient = 90.0 + 80.0 * Double(x) / Double(width)
+                let structure = 40.0 * sin(Double(x) * 0.11) * cos(Double(y) * 0.07)
+                let grain = rng.nextGaussian() * 6
+                let offset = (y * width + x) * 4
+                pixels[offset] = UInt8(min(255, max(0, gradient + structure + grain)))
+                pixels[offset + 1] = UInt8(min(255, max(0, gradient * 0.8 + structure + grain)))
+                pixels[offset + 2] = UInt8(min(255, max(0, gradient * 0.6 - structure + grain)))
+            }
+        }
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        return pixels.withUnsafeMutableBytes { buffer in
+            CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )!.makeImage()!
+        }
+    }
+
+    static func psnr(_ first: CGImage, _ second: CGImage) -> Double {
+        let firstRaster = RGBARaster(image: first)!
+        let secondRaster = RGBARaster(image: second)!
+        var squaredError = 0.0
+        var sampleCount = 0
+        for offset in 0..<(firstRaster.width * firstRaster.height * 4) where offset % 4 != 3 {
+            let difference = Double(firstRaster.pixels[offset]) - Double(secondRaster.pixels[offset])
+            squaredError += difference * difference
+            sampleCount += 1
+        }
+        let meanSquaredError = squaredError / Double(sampleCount)
+        return meanSquaredError > 0 ? 10 * log10(255.0 * 255.0 / meanSquaredError) : .infinity
+    }
+
+    func testDCTRoundTripIsLossless() {
+        var rng = SplitMix64(seed: 8)
+        let block = (0..<64).map { _ in Float(rng.nextDouble() * 255) }
+        var coefficients = [Float](repeating: 0, count: 64)
+        var restored = [Float](repeating: 0, count: 64)
+        DCT8x8.forward(block, into: &coefficients)
+        DCT8x8.inverse(coefficients, into: &restored)
+        for (original, roundTripped) in zip(block, restored) {
+            XCTAssertEqual(original, roundTripped, accuracy: 1e-3)
+        }
+    }
+
+    func testZigzagOrderIsAPermutationStartingAtDC() {
+        XCTAssertEqual(DCT8x8.zigzagOrder.sorted(), Array(0..<64))
+        XCTAssertEqual(DCT8x8.zigzagOrder[0], 0)
+        XCTAssertEqual(DCT8x8.zigzagOrder[1], 1)
+        XCTAssertEqual(DCT8x8.zigzagOrder[2], 8)
+    }
+
+    func testEmbedDetectRoundTrip() throws {
+        let image = Self.makeTestImage(width: 256, height: 256, seed: 1)
+        let key = Fixtures.key(seed: 21)
+        let stamped = try TextureWatermarker.embed(image: image, key: key, parameters: parameters)
+
+        let detection = TextureWatermarker.detect(image: stamped, key: key, parameters: parameters)
+        XCTAssertEqual(detection.chipCount, 32 * 32 * 22)
+        XCTAssertGreaterThan(detection.zScore, 6)
+        XCTAssertLessThan(detection.pValue, 1e-9)
+    }
+
+    func testEmbedIsImperceptible() throws {
+        let image = Self.makeTestImage(width: 256, height: 256, seed: 1)
+        let stamped = try TextureWatermarker.embed(
+            image: image, key: Fixtures.key(seed: 21), parameters: parameters
+        )
+        XCTAssertGreaterThanOrEqual(Self.psnr(image, stamped), 45)
+    }
+
+    func testWrongKeyDetectsAtChanceLevel() throws {
+        let image = Self.makeTestImage(width: 256, height: 256, seed: 1)
+        let stamped = try TextureWatermarker.embed(
+            image: image, key: Fixtures.key(seed: 21), parameters: parameters
+        )
+
+        for seed in 60..<70 {
+            let detection = TextureWatermarker.detect(
+                image: stamped, key: Fixtures.key(seed: UInt8(seed)), parameters: parameters
+            )
+            XCTAssertGreaterThan(detection.pValue, 1e-3, "wrong key seed \(seed) z=\(detection.zScore)")
+            XCTAssertLessThan(abs(detection.zScore), 4)
+        }
+    }
+
+    func testUnmarkedImageDetectsAtChanceLevel() {
+        let image = Self.makeTestImage(width: 256, height: 256, seed: 1)
+        let detection = TextureWatermarker.detect(
+            image: image, key: Fixtures.key(seed: 21), parameters: parameters
+        )
+        XCTAssertGreaterThan(detection.pValue, 1e-3)
+    }
+
+    func testDetectionSurvivesDownscaleWhenRestoredToRecordedSize() throws {
+        let image = Self.makeTestImage(width: 256, height: 256, seed: 1)
+        let key = Fixtures.key(seed: 21)
+        let stamped = try TextureWatermarker.embed(image: image, key: key, parameters: parameters)
+
+        let downscaled = RGBARaster.resample(stamped, width: 192, height: 192)!
+        let detection = TextureWatermarker.detect(
+            image: downscaled, key: key, parameters: parameters, originalSize: (width: 256, height: 256)
+        )
+        XCTAssertLessThan(detection.pValue, 1e-6)
+    }
+}

--- a/RealityMarkKit/Tests/WatermarkCoreTests/WatermarkRecordTests.swift
+++ b/RealityMarkKit/Tests/WatermarkCoreTests/WatermarkRecordTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import WatermarkCore
+
+final class WatermarkRecordTests: XCTestCase {
+    private func makeRecord() -> WatermarkRecord {
+        WatermarkRecord(
+            jobId: UUID(),
+            format: "glb",
+            detailLevel: "full",
+            filename: "chair-full.glb",
+            filePath: "/tmp/chair-full.glb",
+            createdAt: Date(timeIntervalSince1970: 1_752_000_000),
+            key: Fixtures.key(seed: 42),
+            channels: [WatermarkRecord.Channel.geometry, WatermarkRecord.Channel.texture],
+            geometry: .init(
+                parameters: GeometryWatermarkParameters(),
+                effectiveBinCount: 32,
+                embeddedBits: 30
+            ),
+            texture: .init(
+                parameters: TextureWatermarkParameters(),
+                images: [.init(name: "baseColor.png", semantic: "baseColor", width: 2048, height: 2048)]
+            ),
+            fileSHA256: String(repeating: "ab", count: 32)
+        )
+    }
+
+    func testJSONRoundTrip() throws {
+        let record = makeRecord()
+        let data = try record.jsonData()
+        let decoded = try WatermarkRecord(jsonData: data)
+        XCTAssertEqual(decoded, record)
+    }
+
+    func testDetectionParametersUseEffectiveBinCount() {
+        let record = makeRecord()
+        XCTAssertEqual(record.geometry?.parameters.binCount, 64)
+        XCTAssertEqual(record.geometry?.detectionParameters.binCount, 32)
+    }
+
+    func testKeyRoundTripsThroughRecord() throws {
+        let record = makeRecord()
+        XCTAssertEqual(try record.watermarkKey, Fixtures.key(seed: 42))
+    }
+
+    func testVersionsAreStamped() {
+        let record = makeRecord()
+        XCTAssertEqual(record.schemaVersion, WatermarkRecord.currentSchemaVersion)
+        XCTAssertEqual(record.algorithmVersion, WatermarkRecord.currentAlgorithmVersion)
+    }
+}

--- a/RealityMarkKit/Tests/WatermarkCoreTests/WatermarkStatisticsTests.swift
+++ b/RealityMarkKit/Tests/WatermarkCoreTests/WatermarkStatisticsTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import WatermarkCore
+
+final class WatermarkStatisticsTests: XCTestCase {
+    func testBinomialTailKnownValues() {
+        XCTAssertEqual(WatermarkStatistics.binomialTailPValue(matched: 0, total: 10), 1.0, accuracy: 1e-12)
+        XCTAssertEqual(
+            WatermarkStatistics.binomialTailPValue(matched: 10, total: 10),
+            pow(0.5, 10),
+            accuracy: 1e-12
+        )
+        // P[X >= 8], X ~ Bin(10, ½) = (45 + 10 + 1) / 1024
+        XCTAssertEqual(
+            WatermarkStatistics.binomialTailPValue(matched: 8, total: 10),
+            56.0 / 1024.0,
+            accuracy: 1e-12
+        )
+    }
+
+    func testBinomialTailEdgeCases() {
+        XCTAssertEqual(WatermarkStatistics.binomialTailPValue(matched: 0, total: 0), 1.0)
+        XCTAssertEqual(WatermarkStatistics.binomialTailPValue(matched: -5, total: 10), 1.0, accuracy: 1e-12)
+        XCTAssertEqual(
+            WatermarkStatistics.binomialTailPValue(matched: 15, total: 10),
+            pow(0.5, 10),
+            accuracy: 1e-12
+        )
+    }
+
+    func testNormalUpperTailKnownValues() {
+        XCTAssertEqual(WatermarkStatistics.normalUpperTailPValue(z: 0), 0.5, accuracy: 1e-12)
+        XCTAssertEqual(WatermarkStatistics.normalUpperTailPValue(z: 1.6448536269514722), 0.05, accuracy: 1e-9)
+        XCTAssertEqual(WatermarkStatistics.normalUpperTailPValue(z: 3.09023230616781), 1e-3, accuracy: 1e-9)
+    }
+}

--- a/RealityPulse.xcodeproj/project.pbxproj
+++ b/RealityPulse.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		DDDD0018DDDD0018DDDD0018 /* ExportRecordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0016DDDD0016DDDD0016 /* ExportRecordStoreTests.swift */; };
 		DDDD0020DDDD0020DDDD0020 /* USDZStamper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0019DDDD0019DDDD0019 /* USDZStamper.swift */; };
 		DDDD0022DDDD0022DDDD0022 /* USDZStamperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0021DDDD0021DDDD0021 /* USDZStamperTests.swift */; };
+		DDDD0024DDDD0024DDDD0024 /* PersistentWatermarkKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0023DDDD0023DDDD0023 /* PersistentWatermarkKey.swift */; };
 		DDDD0004DDDD0004DDDD0004 /* WatermarkCore in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0002DDDD0002DDDD0002 /* WatermarkCore */; };
 		DDDD0005DDDD0005DDDD0005 /* ModelFileIO in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0003DDDD0003DDDD0003 /* ModelFileIO */; };
 		DDDD0008DDDD0008DDDD0008 /* WatermarkCore in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0006DDDD0006DDDD0006 /* WatermarkCore */; };
@@ -109,6 +110,7 @@
 		DDDD0016DDDD0016DDDD0016 /* ExportRecordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportRecordStoreTests.swift; sourceTree = "<group>"; };
 		DDDD0019DDDD0019DDDD0019 /* USDZStamper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USDZStamper.swift; sourceTree = "<group>"; };
 		DDDD0021DDDD0021DDDD0021 /* USDZStamperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USDZStamperTests.swift; sourceTree = "<group>"; };
+		DDDD0023DDDD0023DDDD0023 /* PersistentWatermarkKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentWatermarkKey.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -262,6 +264,7 @@
 				C98675D558934377A48B11EB /* */,
 				E3A4F851B39B9C4EA08E7C13 /* */,
 				DDDD0010DDDD0010DDDD0010 /* PersistentExportRecord.swift */,
+				DDDD0023DDDD0023DDDD0023 /* PersistentWatermarkKey.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				6E179F522E3A43939DF5BF80 /* PersistentScheduleSettings.swift in Sources */,
 				5EF33318F00E443A81683739 /* PersistentMigrationState.swift in Sources */,
 				DDDD0011DDDD0011DDDD0011 /* PersistentExportRecord.swift in Sources */,
+				DDDD0024DDDD0024DDDD0024 /* PersistentWatermarkKey.swift in Sources */,
 				DDDD0013DDDD0013DDDD0013 /* WatermarkingService.swift in Sources */,
 				DDDD0020DDDD0020DDDD0020 /* USDZStamper.swift in Sources */,
 				0DA909603009039BB1FEB542 /* JobDraft.swift in Sources */,

--- a/RealityPulse.xcodeproj/project.pbxproj
+++ b/RealityPulse.xcodeproj/project.pbxproj
@@ -38,6 +38,16 @@
 		BBBB0005BBBB0005BBBB0005 /* SplatPLYWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0005AAAA0005AAAA0005 /* SplatPLYWriter.swift */; };
 		BBBB0006BBBB0006BBBB0006 /* SplatSampleGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0006AAAA0006AAAA0006 /* SplatSampleGenerator.swift */; };
 		BBBB0007BBBB0007BBBB0007 /* SplatGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0007AAAA0007AAAA0007 /* SplatGenerationTests.swift */; };
+		DDDD0011DDDD0011DDDD0011 /* PersistentExportRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0010DDDD0010DDDD0010 /* PersistentExportRecord.swift */; };
+		DDDD0013DDDD0013DDDD0013 /* WatermarkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0012DDDD0012DDDD0012 /* WatermarkingService.swift */; };
+		DDDD0017DDDD0017DDDD0017 /* WatermarkExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0015DDDD0015DDDD0015 /* WatermarkExportTests.swift */; };
+		DDDD0018DDDD0018DDDD0018 /* ExportRecordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0016DDDD0016DDDD0016 /* ExportRecordStoreTests.swift */; };
+		DDDD0020DDDD0020DDDD0020 /* USDZStamper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0019DDDD0019DDDD0019 /* USDZStamper.swift */; };
+		DDDD0022DDDD0022DDDD0022 /* USDZStamperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDD0021DDDD0021DDDD0021 /* USDZStamperTests.swift */; };
+		DDDD0004DDDD0004DDDD0004 /* WatermarkCore in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0002DDDD0002DDDD0002 /* WatermarkCore */; };
+		DDDD0005DDDD0005DDDD0005 /* ModelFileIO in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0003DDDD0003DDDD0003 /* ModelFileIO */; };
+		DDDD0008DDDD0008DDDD0008 /* WatermarkCore in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0006DDDD0006DDDD0006 /* WatermarkCore */; };
+		DDDD0009DDDD0009DDDD0009 /* ModelFileIO in Frameworks */ = {isa = PBXBuildFile; productRef = DDDD0007DDDD0007DDDD0007 /* ModelFileIO */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +103,12 @@
 		AAAA0005AAAA0005AAAA0005 /* SplatPLYWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplatPLYWriter.swift; sourceTree = "<group>"; };
 		AAAA0006AAAA0006AAAA0006 /* SplatSampleGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplatSampleGenerator.swift; sourceTree = "<group>"; };
 		AAAA0007AAAA0007AAAA0007 /* SplatGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplatGenerationTests.swift; sourceTree = "<group>"; };
+		DDDD0010DDDD0010DDDD0010 /* PersistentExportRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentExportRecord.swift; sourceTree = "<group>"; };
+		DDDD0012DDDD0012DDDD0012 /* WatermarkingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatermarkingService.swift; sourceTree = "<group>"; };
+		DDDD0015DDDD0015DDDD0015 /* WatermarkExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatermarkExportTests.swift; sourceTree = "<group>"; };
+		DDDD0016DDDD0016DDDD0016 /* ExportRecordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportRecordStoreTests.swift; sourceTree = "<group>"; };
+		DDDD0019DDDD0019DDDD0019 /* USDZStamper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USDZStamper.swift; sourceTree = "<group>"; };
+		DDDD0021DDDD0021DDDD0021 /* USDZStamperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USDZStamperTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -120,6 +136,7 @@
 				ReconstructionOptions/ExportFormatView.swift,
 				ReconstructionOptions/QualityView.swift,
 				ReconstructionOptions/ReconstructionOptionsView.swift,
+				ReconstructionOptions/WatermarkOptionView.swift,
 				SettingsView.swift,
 			);
 			target = F974D1152BE0484500EFACBA /* ObjectCaptureReconstruction */;
@@ -135,6 +152,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDDD0004DDDD0004DDDD0004 /* WatermarkCore in Frameworks */,
+				DDDD0005DDDD0005DDDD0005 /* ModelFileIO in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -142,6 +161,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDDD0008DDDD0008DDDD0008 /* WatermarkCore in Frameworks */,
+				DDDD0009DDDD0009DDDD0009 /* ModelFileIO in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -159,6 +180,14 @@
 				26B095482C091BEA0097324A /* BottomBarView.swift */,
 			);
 			path = Processing;
+			sourceTree = "<group>";
+		};
+		DDDD0014DDDD0014DDDD0014 /* Watermark */ = {
+			isa = PBXGroup;
+			children = (
+				DDDD0012DDDD0012DDDD0012 /* WatermarkingService.swift */,
+			);
+			path = Watermark;
 			sourceTree = "<group>";
 		};
 		BD87F13DD4B2159CCB69FFA2 /* Configuration */ = {
@@ -201,6 +230,7 @@
 				26B0954A2C091C770097324A /* ThumbnailView.swift */,
 				26B095232C091B810097324A /* Processing */,
 				26B095212C091B740097324A /* Settings */,
+				DDDD0014DDDD0014DDDD0014 /* Watermark */,
 				AAC7DC5DCD23638D271D3093 /* Models */,
 				992CB303C65294FA4C0E9608 /* Scheduler */,
 				195BAF6352F89DD77AFC2745 /* Store */,
@@ -231,6 +261,7 @@
 				A88318DE6F7346A38820D6CA /* */,
 				C98675D558934377A48B11EB /* */,
 				E3A4F851B39B9C4EA08E7C13 /* */,
+				DDDD0010DDDD0010DDDD0010 /* PersistentExportRecord.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -268,6 +299,7 @@
 				E8F9A0B1C2D3E4F5A6B7C8DA /* GLTFSchema.swift */,
 				E8F9A0B1C2D3E4F5A6B7C8DC /* USDZToGLTFConverter.swift */,
 				AAAA0001AAAA0001AAAA0001 /* MeshGeometryReader.swift */,
+				DDDD0019DDDD0019DDDD0019 /* USDZStamper.swift */,
 			);
 			path = Export;
 			sourceTree = "<group>";
@@ -278,6 +310,9 @@
 				D729E04F4B0947929FF2F4C2 /* JobStoreTests.swift */,
 				F1E2D3C4B5A6978899AABBCD /* ModelExportTests.swift */,
 				AAAA0007AAAA0007AAAA0007 /* SplatGenerationTests.swift */,
+				DDDD0015DDDD0015DDDD0015 /* WatermarkExportTests.swift */,
+				DDDD0016DDDD0016DDDD0016 /* ExportRecordStoreTests.swift */,
+				DDDD0021DDDD0021DDDD0021 /* USDZStamperTests.swift */,
 			);
 			path = ObjectCaptureReconstructionTests;
 			sourceTree = "<group>";
@@ -310,6 +345,10 @@
 			dependencies = (
 			);
 			name = ObjectCaptureReconstruction;
+			packageProductDependencies = (
+				DDDD0002DDDD0002DDDD0002 /* WatermarkCore */,
+				DDDD0003DDDD0003DDDD0003 /* ModelFileIO */,
+			);
 			productName = ObjectCaptureReconstruction;
 			productReference = F974D1162BE0484500EFACBA /* Reality Pulse.app */;
 			productType = "com.apple.product-type.application";
@@ -328,6 +367,10 @@
 				10FB862EFFF74E3D88EE52D4 /* PBXTargetDependency */,
 			);
 			name = ObjectCaptureReconstructionTests;
+			packageProductDependencies = (
+				DDDD0006DDDD0006DDDD0006 /* WatermarkCore */,
+				DDDD0007DDDD0007DDDD0007 /* ModelFileIO */,
+			);
 			productName = ObjectCaptureReconstructionTests;
 			productReference = F5A38ACB50CF47AE95A5E30A /* ObjectCaptureReconstructionTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -361,6 +404,9 @@
 				Base,
 			);
 			mainGroup = F974D10D2BE0484500EFACBA;
+			packageReferences = (
+				DDDD0001DDDD0001DDDD0001 /* XCLocalSwiftPackageReference "RealityMarkKit" */,
+			);
 			productRefGroup = F974D1172BE0484500EFACBA /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -406,6 +452,9 @@
 				4BC3F99B1E9F4DFF83756389 /* PersistentJob.swift in Sources */,
 				6E179F522E3A43939DF5BF80 /* PersistentScheduleSettings.swift in Sources */,
 				5EF33318F00E443A81683739 /* PersistentMigrationState.swift in Sources */,
+				DDDD0011DDDD0011DDDD0011 /* PersistentExportRecord.swift in Sources */,
+				DDDD0013DDDD0013DDDD0013 /* WatermarkingService.swift in Sources */,
+				DDDD0020DDDD0020DDDD0020 /* USDZStamper.swift in Sources */,
 				0DA909603009039BB1FEB542 /* JobDraft.swift in Sources */,
 				4A45C797C462E066F321F944 /* JobScheduler.swift in Sources */,
 				8EDA871038ABBECE6E11AF17 /* JobStore.swift in Sources */,
@@ -431,6 +480,9 @@
 				DA46AD02680942AA94FEBCBB /* JobStoreTests.swift in Sources */,
 				F1E2D3C4B5A6978899AABBCC /* ModelExportTests.swift in Sources */,
 				BBBB0007BBBB0007BBBB0007 /* SplatGenerationTests.swift in Sources */,
+				DDDD0017DDDD0017DDDD0017 /* WatermarkExportTests.swift in Sources */,
+				DDDD0018DDDD0018DDDD0018 /* ExportRecordStoreTests.swift in Sources */,
+				DDDD0022DDDD0022DDDD0022 /* USDZStamperTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -733,6 +785,32 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		DDDD0001DDDD0001DDDD0001 /* XCLocalSwiftPackageReference "RealityMarkKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = RealityMarkKit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		DDDD0002DDDD0002DDDD0002 /* WatermarkCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WatermarkCore;
+		};
+		DDDD0003DDDD0003DDDD0003 /* ModelFileIO */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ModelFileIO;
+		};
+		DDDD0006DDDD0006DDDD0006 /* WatermarkCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WatermarkCore;
+		};
+		DDDD0007DDDD0007DDDD0007 /* ModelFileIO */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ModelFileIO;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = F974D10E2BE0484500EFACBA /* Project object */;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,12 +150,41 @@ chance level.
 Coverage per format: USDZ = texture only (v1), PLY = geometry only,
 glTF/GLB = both. The scheduler finalizes a job by exporting derived formats
 first (from the still-pristine USDZ) and stamping the USDZ last, so every
-distributed file maps to exactly one record and one fresh key.
+distributed file maps to exactly one record.
+
+### Key granularity
+
+The job setup sheet offers two key sources whenever watermarking is on:
+
+- **New key per file** (default) — every exported file gets a freshly
+  generated 256-bit key. This is full *traitor tracing*: a leaked copy
+  identifies the exact file, so different recipients are distinguishable.
+- **A saved key** — a labeled key from the key library
+  (`PersistentWatermarkKey`: unique id, unique label, key material,
+  created/last-used timestamps) is reused for every file of the job, and can
+  be reused across jobs. Labels are created in the sheet ("New Saved Key…")
+  and are trimmed, non-empty, and unique.
+
+Reusing a key deliberately trades tracing for a different property. Every
+copy carries the same mark, so a leak proves *ownership* ("this is my
+export") but not *which* copy leaked. In exchange it resists collusion: two
+recipients comparing byte-identical copies find no differences to average
+away, whereas per-copy keys give colluders exactly that signal. Neither is
+strictly better — per-copy is the default because losing tracing should be a
+deliberate act, not an accident.
+
+Records store the label alongside the key (`keyLabel`, nil for per-copy
+keys), and the verifier prints which regime applies so a result is never
+misread as identifying a single copy when it cannot. A saved key that was
+deleted since the job was created falls back to per-copy keys, with a warning
+in the completion notification — strictly more traceable, but not what was
+asked for.
 
 ### Records and verification
 
-Each stamped file gets a `PersistentExportRecord` row (SwiftData): per-copy
-key, channels, embedding parameters, and the file's SHA-256. Records are
+Each stamped file gets a `PersistentExportRecord` row (SwiftData): the
+key (and its label when reused), channels, embedding parameters, and the
+file's SHA-256. Records are
 append-only provenance history and survive job deletion. An internal record
 export ("Export Provenance Records…" in the job context menu, hidden behind
 `defaults write <bundle-id> RPWatermarkRecordExport -bool YES`) writes them as
@@ -185,6 +214,10 @@ Record JSONs contain the secret keys — treat them as credentials.
 - Keys live only in the app's SwiftData store and exported record JSONs;
   losing the store means losing verifiability, and anyone with the Mac
   account (or a record file) can remove or transplant marks.
+- A reused saved key identifies the key, not an individual copy: every file
+  marked with it is indistinguishable, so it cannot answer "which recipient
+  leaked this". It also widens blast radius — one leaked record JSON exposes
+  the key for every file ever marked with it, not just one export.
 - Manual re-exports (and derived exports re-run when a job completes again
   from already-stamped outputs) come from an already-stamped USDZ and get
   texture-double-marked. Benign: independent-key patterns are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,6 +112,83 @@ The `Processing/` views display progress, estimated time remaining, completion s
 
 The app is sandboxed. User-selected input and output folders are stored with security-scoped bookmarks so the queue can access them after relaunch.
 
+## Provenance Watermarking
+
+Jobs can opt in (per-job toggle, default off) to embedding an imperceptible,
+per-copy provenance watermark in every exported file, so a copy found in the
+wild can be traced back to the export that produced it. The implementation
+lives in the local Swift package `RealityMarkKit/` (`WatermarkCore` +
+`ModelFileIO`), shared by the app and the internal `watermark-verify` CLI so
+embedding and detection can never drift apart.
+
+### Open design
+
+This repository is public, so the scheme follows Kerckhoffs's principle: the
+algorithm hides nothing, and all security rests on a per-copy 256-bit secret
+key. Every keyed decision (bit sequence, bin permutation, chip signs) is
+derived from that key via HMAC-SHA256; without the key the mark can be
+neither read, forged, nor selectively targeted. Wrong keys detect at exactly
+chance level.
+
+### Channels
+
+- **Geometry** — a blind keyed statistical watermark on the distribution of
+  vertex radial norms (Cho–Prost–Jung, IEEE TSP 2007, hardened with
+  trimmed-quantile range normalization). Norms are computed against the
+  centroid and normalized over a trimmed range, so detection is invariant to
+  vertex reordering, translation, rotation, and uniform scale, and needs only
+  the position multiset — no topology. One bit per norm bin; vertices move at
+  most one bin width (≲0.5% of the bounding-box diagonal). Applied to
+  glTF/GLB vertices and Gaussian-splat PLY points.
+- **Texture** — a blind additive spread-spectrum mark in the mid-band 8×8 DCT
+  coefficients of the base-color luma plane (PSNR ≥ 45 dB). Survives PNG/JPEG
+  re-encoding and mild rescaling (the detector resamples suspects back to the
+  recorded size). Applied to glTF/GLB base-color images and, via a
+  stored-zip repack that never touches the `.usdc` geometry bytes, to the
+  USDZ itself.
+
+Coverage per format: USDZ = texture only (v1), PLY = geometry only,
+glTF/GLB = both. The scheduler finalizes a job by exporting derived formats
+first (from the still-pristine USDZ) and stamping the USDZ last, so every
+distributed file maps to exactly one record and one fresh key.
+
+### Records and verification
+
+Each stamped file gets a `PersistentExportRecord` row (SwiftData): per-copy
+key, channels, embedding parameters, and the file's SHA-256. Records are
+append-only provenance history and survive job deletion. An internal record
+export ("Export Provenance Records…" in the job context menu, hidden behind
+`defaults write <bundle-id> RPWatermarkRecordExport -bool YES`) writes them as
+`*.wmrecord.json` for the offline verifier:
+
+```
+swift build --package-path RealityMarkKit -c release
+RealityMarkKit/.build/release/watermark-verify --record <record.json> <suspect-file>
+```
+
+The CLI loads geometry/images from usdz, glb, gltf, ply, png, or jpg
+suspects, reports per-channel match statistics with binomial/normal-tail
+p-values, and prints a MATCH / LIKELY / NO MATCH verdict (exit codes 0/1/2).
+Record JSONs contain the secret keys — treat them as credentials.
+
+### Known limitations
+
+- Aggressive remeshing plus full texture replacement strips both channels;
+  heavy decimation (≫50%), non-uniform scaling, or shearing breaks the
+  geometry statistic; large crops/warps or AI re-texturing break the texture
+  channel.
+- The algorithm being public means an attacker can run targeted
+  distribution-flattening or mid-band-scrubbing attacks — at a measurable
+  quality cost. The mark traces and deters; it is not DRM.
+- Cropping or part-extraction shifts the centroid, degrading partial-mesh
+  geometry detection; texture detection assumes approximate origin alignment.
+- Keys live only in the app's SwiftData store and exported record JSONs;
+  losing the store means losing verifiability, and anyone with the Mac
+  account (or a record file) can remove or transplant marks.
+- Manual re-exports from an already-stamped USDZ get texture-double-marked
+  (benign: independent-key patterns are quasi-orthogonal and each record
+  still verifies independently).
+
 ## Test Coverage
 
 The focused test target verifies:
@@ -125,3 +202,11 @@ The focused test target verifies:
 - completed-output preservation on retry
 - stale output deletion before retry
 - one-time legacy JSON migration
+- watermark embed → export → read-back → detect round trips (GLB, PLY, USDZ)
+- provenance-record persistence, idempotence lookups, and job-deletion survival
+
+`RealityMarkKit/` has its own test suite (`swift test --package-path
+RealityMarkKit`) covering keyed-PRF determinism, geometry roundtrip and
+robustness (noise, similarity transforms, reordering, subsampling), false
+positives at chance level, imperceptibility bounds, texture PSNR and
+JPEG/rescale robustness, and usdz archive alignment.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,9 +185,10 @@ Record JSONs contain the secret keys — treat them as credentials.
 - Keys live only in the app's SwiftData store and exported record JSONs;
   losing the store means losing verifiability, and anyone with the Mac
   account (or a record file) can remove or transplant marks.
-- Manual re-exports from an already-stamped USDZ get texture-double-marked
-  (benign: independent-key patterns are quasi-orthogonal and each record
-  still verifies independently).
+- Manual re-exports (and derived exports re-run when a job completes again
+  from already-stamped outputs) come from an already-stamped USDZ and get
+  texture-double-marked. Benign: independent-key patterns are
+  quasi-orthogonal and each record still verifies independently.
 
 ## Test Coverage
 

--- a/website/src/content/docs/architecture.md
+++ b/website/src/content/docs/architecture.md
@@ -1,10 +1,10 @@
 ---
 title: Architecture
-description: How Reality Pulse is structured around a persistent Object Capture queue.
+description: How Reality Pulse automates Object Capture reconstruction and multi-format export.
 order: 2
 ---
 
-Reality Pulse is a native macOS SwiftUI app built around Apple Object Capture's `PhotogrammetrySession`. The app's main responsibility is to turn single-session reconstruction into a persistent, scheduled, retryable queue.
+Reality Pulse is a native macOS SwiftUI app built around Apple Object Capture's `PhotogrammetrySession`. Its main responsibility is to turn single-session reconstruction into a persistent, scheduled, retryable automation pipeline—from photo folders to USDZ meshes and optional glTF, glB, or Gaussian splat exports.
 
 ## Runtime Flow
 
@@ -23,7 +23,8 @@ ObjectCaptureReconstructionApp
 3. The queue UI edits `ReconstructionJob` values through `JobScheduler`.
 4. `JobScheduler` selects the next pending job, resolves folder bookmarks, and creates a `PhotogrammetrySession`.
 5. Session outputs update progress, completion metadata, job status, and user notifications.
-6. `JobStore` persists every meaningful queue and schedule mutation through SwiftData.
+6. Optional post-processing converts completed USDZ files to glTF, glB, or Gaussian splat `.ply`.
+7. `JobStore` persists every meaningful queue and schedule mutation through SwiftData.
 
 ## Main Components
 
@@ -49,8 +50,9 @@ ObjectCaptureReconstructionApp
 
 ### UI Areas
 
-- `Settings/`: SwiftUI controls for folder selection and `PhotogrammetrySession.Configuration`.
+- `Settings/`: SwiftUI controls for folder selection, `PhotogrammetrySession.Configuration`, and export format selection.
 - `Processing/`: progress display and USDZ preview with RealityKit.
 - `Queue/`: dashboard and job setup views.
+- `Export/`: USDZ to glTF/glB conversion and Gaussian splat generation.
 
 For deeper implementation notes, see the [architecture guide in the repository](https://github.com/nuit-dhiver/reality-pulse/blob/main/docs/ARCHITECTURE.md).

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -1,10 +1,10 @@
 ---
 title: Getting Started
-description: Build, test, and run Reality Pulse on macOS.
+description: Build, test, and run the Reality Pulse 3D automation suite on macOS.
 order: 1
 ---
 
-Reality Pulse is a native macOS app. Clone the repository, open the Xcode project, and build the `RealityPulse` scheme.
+Reality Pulse is a native macOS app for automating 3D model creation with Apple Object Capture. Clone the repository, open the Xcode project, and build the `RealityPulse` scheme.
 
 ## Requirements
 
@@ -44,12 +44,12 @@ The test suite covers SwiftData persistence, schedule reloads, launch recovery, 
 
 1. Add a job from the queue dashboard.
 2. Pick an image folder and an output folder.
-3. Name the model and choose Object Capture settings.
-4. Optionally enable additional detail-level exports.
+3. Name the model and choose Object Capture reconstruction settings.
+4. Select detail levels for USDZ output and, optionally, additional export formats (glTF, glB, or Gaussian splat `.ply`).
 5. Add more jobs, reorder them, and configure a schedule.
 6. Press **Start** when you want the queue to run.
 
-Reality Pulse restores the queue on launch, but it does not automatically start processing after a relaunch.
+Reality Pulse reconstructs each job with `PhotogrammetrySession`, writes USDZ meshes, then generates any selected secondary formats from the completed reconstruction. The queue restores on launch, but it does not automatically start processing after a relaunch.
 
 ## Releases
 

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ interface Props {
 	description?: string;
 }
 
-const { title, description = 'A macOS photogrammetry queue for Apple Object Capture.' } = Astro.props;
+const { title, description = 'An automation suite for creating 3D models on macOS with Apple Object Capture.' } = Astro.props;
 const siteTitle = title === 'Reality Pulse' ? title : `${title} · Reality Pulse`;
 const homePath = withBase();
 const docsPath = withBase('docs/');
@@ -44,7 +44,7 @@ const docsPath = withBase('docs/');
 
 		<footer class="site-footer">
 			<div class="container">
-				<p>Reality Pulse — macOS photogrammetry queue for Apple Object Capture.</p>
+				<p>Reality Pulse — macOS automation for 3D model creation with Apple Object Capture.</p>
 				<p>
 					<a href="https://github.com/nuit-dhiver/reality-pulse">Source</a>
 					&nbsp;·&nbsp;

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -6,7 +6,7 @@ import { withBase } from '../../utils/paths';
 
 <DocLayout title="Documentation" description="Guides and reference for Reality Pulse.">
 	<h1>Documentation</h1>
-	<p>Guides for building, running, and contributing to Reality Pulse.</p>
+	<p>Guides for building, running, and contributing to the Reality Pulse 3D automation suite on macOS.</p>
 
 	<ul class="doc-list">
 		{

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -5,11 +5,12 @@ import { withBase } from '../utils/paths';
 
 <BaseLayout title="Reality Pulse">
 	<section class="hero container">
-		<p class="hero-eyebrow">macOS · SwiftUI · Object Capture</p>
-		<h1>Batch photogrammetry for Apple Object Capture</h1>
+		<p class="hero-eyebrow">macOS · 3D automation · Object Capture</p>
+		<h1>Automate 3D model creation on macOS</h1>
 		<p class="hero-lead">
-			Reality Pulse turns folders of photos into USDZ 3D models with a persistent queue, scheduled
-			processing windows, SwiftData persistence, and crash-aware retry recovery.
+			Reality Pulse is an automation suite for turning photo captures into production-ready 3D assets.
+			Queue folders through Apple Object Capture, export USDZ meshes, convert to glTF or glB for the web,
+			generate Gaussian splats as <code>.ply</code>, and let your Mac run the pipeline on a schedule.
 		</p>
 		<div class="hero-actions">
 			<a class="button button-primary" href={withBase('docs/getting-started/')}>Get started</a>
@@ -18,41 +19,77 @@ import { withBase } from '../utils/paths';
 	</section>
 
 	<section class="section container">
-		<h2 class="section-title">Why Reality Pulse?</h2>
+		<h2 class="section-title">More than a batch queue</h2>
 		<p>
-			Apple Object Capture is powerful, but running one folder at a time is tedious when you are
-			scanning products, props, archive objects, or environment assets. Reality Pulse wraps
-			<code>PhotogrammetrySession</code> in a persistent queue so you can prepare a batch, choose
-			output quality, and let the Mac process the work in order.
+			Apple Object Capture is powerful, but running one folder at a time does not scale when you are
+			scanning products, props, archive objects, or environment assets. Reality Pulse wraps the full
+			workflow in a persistent automation layer: prepare jobs, pick reconstruction settings, choose
+			export formats, and walk away while the Mac processes everything in order.
+		</p>
+		<p>
+			The goal is simple—make 3D model creation on macOS easy. Less clicking through repeated
+			reconstructions, fewer manual format conversions, and a queue that survives overnight runs,
+			app restarts, and interrupted jobs.
 		</p>
 	</section>
 
 	<section class="section container">
-		<h2 class="section-title">Features</h2>
+		<h2 class="section-title">Output formats</h2>
+		<p>
+			Every job starts with Apple Object Capture and produces USDZ photogrammetry meshes. From there,
+			you can optionally generate additional formats from the same reconstruction:
+		</p>
 		<div class="card-grid">
 			<article class="card">
-				<h3>Batch queue</h3>
-				<p>Add multiple image folders and process them sequentially with full queue control.</p>
+				<h3>USDZ</h3>
+				<p>
+					Native Object Capture output in preview, reduced, medium, full, raw, or custom detail
+					levels—one or more meshes per job.
+				</p>
 			</article>
 			<article class="card">
-				<h3>Multiple detail levels</h3>
-				<p>Generate preview, reduced, medium, full, raw, or custom USDZ outputs from one capture.</p>
+				<h3>glTF &amp; glB</h3>
+				<p>
+					Convert completed USDZ models to glTF or binary glB for web viewers, game engines, and
+					pipelines that do not use USDZ.
+				</p>
+			</article>
+			<article class="card">
+				<h3>Gaussian splats (.ply)</h3>
+				<p>
+					Export photogrammetry results as Gaussian splat point clouds in standard <code>.ply</code>
+					format for splat viewers and research workflows.
+				</p>
+			</article>
+		</div>
+	</section>
+
+	<section class="section container">
+		<h2 class="section-title">Automation features</h2>
+		<div class="card-grid">
+			<article class="card">
+				<h3>Persistent job queue</h3>
+				<p>Add, reorder, edit, and retry multiple capture folders—process them sequentially without babysitting each run.</p>
 			</article>
 			<article class="card">
 				<h3>Scheduled processing</h3>
-				<p>Delay a queue run or restrict processing to allowed hours, including overnight windows.</p>
+				<p>Delay a queue start or restrict runs to allowed hours, including overnight windows.</p>
 			</article>
 			<article class="card">
 				<h3>SwiftData persistence</h3>
-				<p>Queue jobs, history, schedule settings, and recovery metadata survive app quits and crashes.</p>
+				<p>Jobs, history, schedule settings, and recovery metadata survive app quits and crashes.</p>
 			</article>
 			<article class="card">
 				<h3>Retry-safe exports</h3>
 				<p>Completed outputs are skipped on retry while stale partial files are replaced before resuming.</p>
 			</article>
 			<article class="card">
-				<h3>Progress and notifications</h3>
-				<p>Track job progress, estimated time remaining, failures, and queue completion.</p>
+				<h3>Reconstruction controls</h3>
+				<p>Configure mesh type, masking, polygon limits, texture maps, format, and resolution per job.</p>
+			</article>
+			<article class="card">
+				<h3>Progress &amp; notifications</h3>
+				<p>Track reconstruction progress, estimated time remaining, failures, and queue completion.</p>
 			</article>
 		</div>
 	</section>
@@ -61,8 +98,7 @@ import { withBase } from '../utils/paths';
 		<h2 class="section-title">Documentation</h2>
 		<p>
 			Guides for building, testing, and understanding the app live in the
-			<a href={withBase('docs/')}>docs section</a>. More pages will be added here as
-			the project grows.
+			<a href={withBase('docs/')}>docs section</a>. More pages will be added as the automation suite grows.
 		</p>
 	</section>
 </BaseLayout>


### PR DESCRIPTION
Introduce provenance watermarking for USDZ, glTF/glB, and PLY exports via the new RealityMarkKit package. Each exported file gets a unique per-copy secret key embedded imperceptibly via geometry vertex distribution (Cho–Prost–Jung) and texture mid-band DCT (spread spectrum). Watermarks survive re-encoding and transformations; detection is keyed so wrong keys detect at chance level. Includes export record persistence (SwiftData), optional record JSON export for offline verification, and a watermark-verify CLI tool. Adds UI toggle for per-job watermarking, scheduler finalization that exports formats first then stamps USDZ last, and comprehensive tests.